### PR TITLE
GraphPageのNBのtitle設定用メソッドの調整とControllerのリファクタリング

### DIFF
--- a/DietApp/GraphPage/GraphViewController.swift
+++ b/DietApp/GraphPage/GraphViewController.swift
@@ -37,8 +37,6 @@ class GraphViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
       
-      graphView.navigationBar.backgroundColor = UIColor.cyan
-      
       UIDevice.current.setValue(4, forKey: "orientation")
       
       //画面の向きを変更させるために呼び出す。
@@ -54,9 +52,9 @@ class GraphViewController: UIViewController {
   }
     
   func navigationBarTitleSetting (){
+    
     let yearText = "2023"
-    let dateText = "5/1 ~ 5/31"
-    let dayOfWeekText = "wed"
+    let dateText = "5.1 - 5.31"
     let dateFontSize: CGFloat = 18.0
     let fontSize: CGFloat = 14.0
     
@@ -76,21 +74,13 @@ class GraphViewController: UIViewController {
     dateTextLabel.textColor = .black
     dateTextLabel.sizeToFit()
 
-    let dayOfWeekTextLabel = UILabel(frame: CGRect(x: 0, y: 0, width: 100, height: 22))
-    dayOfWeekTextLabel.text = dayOfWeekText
-    dayOfWeekTextLabel.font = UIFont(name: "Thonburi", size: fontSize)
-    dayOfWeekTextLabel.textColor = .black
-    dayOfWeekTextLabel.sizeToFit()
-
     //AutoLayoutを使用するための設定
     yearTextLabel.translatesAutoresizingMaskIntoConstraints = false
     dateTextLabel.translatesAutoresizingMaskIntoConstraints = false
-    dayOfWeekTextLabel.translatesAutoresizingMaskIntoConstraints = false
-
+  
     // カスタムビューにUILabelを追加
     customTitleView.addSubview(yearTextLabel)
     customTitleView.addSubview(dateTextLabel)
-    customTitleView.addSubview(dayOfWeekTextLabel)
 
     //AutoLayoutの設定
     NSLayoutConstraint.activate([
@@ -98,15 +88,12 @@ class GraphViewController: UIViewController {
       yearTextLabel.centerYAnchor.constraint(equalTo: customTitleView.centerYAnchor),
       //この制約については後日確認
       yearTextLabel.leadingAnchor.constraint(equalTo: yearTextLabel.leadingAnchor),
-      //yearTextLabelの右端は隣のラベルであるdateTextLabelの左端より−１０ポイント（１０ポイント左）になるように制約する
+      //yearTextLabelの右端は隣のラベルであるdateTextLabelの左端より−１2ポイント（１2ポイント左）になるように制約する
       yearTextLabel.trailingAnchor.constraint(equalTo: dateTextLabel.leadingAnchor, constant:  -12.0),
 
       dateTextLabel.centerYAnchor.constraint(equalTo: customTitleView.centerYAnchor),
-      dateTextLabel.trailingAnchor.constraint(equalTo: dayOfWeekTextLabel.leadingAnchor, constant: -12.0),
+      dateTextLabel.trailingAnchor.constraint(equalTo: dateTextLabel.trailingAnchor),
       dateTextLabel.centerXAnchor.constraint(equalTo: customTitleView.centerXAnchor),
-
-      dayOfWeekTextLabel.centerYAnchor.constraint(equalTo: customTitleView.centerYAnchor),
-      dayOfWeekTextLabel.trailingAnchor.constraint(equalTo: dayOfWeekTextLabel.trailingAnchor)
 
     ])
     //カスタムビューをNavigationBarに追加

--- a/DietApp/TopPage/TopViewController.swift
+++ b/DietApp/TopPage/TopViewController.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 class TopViewController: UIViewController {
-//topViewの保持
+
   var topView = TopView()
   
   var tabBarHeight: CGFloat {
@@ -26,6 +26,7 @@ class TopViewController: UIViewController {
     }
     return 0
   }
+  //各セルの高さの定義
   var weightTableViewCellHeight:CGFloat = 70.0
   var memoTableViewCellHeight:CGFloat = 47.0
   var photoTableViewCellHeight: CGFloat {
@@ -42,11 +43,9 @@ class TopViewController: UIViewController {
 
     //スクロールできないようにする
     topView.tableView.isScrollEnabled = false
-    
+    //tableViewCellの高さの自動設定
     topView.tableView.rowHeight = UITableView.automaticDimension
-    
-    topView.navigationBar.backgroundColor = UIColor.cyan
-    
+    //セル間の区切り線を非表示
     topView.tableView.separatorStyle = .none
     
     navigationBarTitleSetting()
@@ -168,8 +167,6 @@ extension TopViewController: UITableViewDelegate,UITableViewDataSource {
       print("セルの取得に失敗しました")
     }
     return cell
-//    let cell = tableView.dequeueReusableCell(withIdentifier: "WeightTableViewCell", for: indexPath) as! WeightTableViewCell
-//    return cell
   }
   //各セルの高さの推定値を設定
   func tableView(_ tableView: UITableView, estimatedHeightForRowAt indexPath: IndexPath) -> CGFloat {
@@ -186,7 +183,7 @@ extension TopViewController: UITableViewDelegate,UITableViewDataSource {
       return 44.0
     }
   }
-  //セルの高さ
+  //セルの高さの設定
   func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
     switch indexPath.row {
     case 0:
@@ -201,29 +198,4 @@ extension TopViewController: UITableViewDelegate,UITableViewDataSource {
       return 44.0
     }
   }
-  
-//  func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-//    // 最初のセクションの間隔は0とする
-//    if section > 0 {
-//      // セクション間の間隔
-//      return sectionMargin
-//    }
-//    //0ではなく.leastNormalMagnitudeにしないと最初のセクションのヘッダーが完全に消えない
-//    return .leastNormalMagnitude
-//  }
-//  
-//  func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-//    let headerView = UIView()
-//    headerView.backgroundColor = .clear
-//    return headerView
-//  }
-//  
-//  func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
-//    //0ではなく.leastNormalMagnitudeにしないとフッターが完全に消えない
-//    return .leastNormalMagnitude
-//  }
-//  
-//  func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
-//    return nil
-//  }
 }

--- a/DietApp/View/GraphPage/GraphView.xib
+++ b/DietApp/View/GraphPage/GraphView.xib
@@ -22,6 +22,7 @@
                 <navigationBar contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="W5m-cm-4a6">
                     <rect key="frame" x="0.0" y="0.0" width="896" height="44"/>
                     <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
+                    <color key="backgroundColor" systemColor="systemCyanColor"/>
                     <items>
                         <navigationItem id="Kp2-xc-LxT">
                             <barButtonItem key="leftBarButtonItem" title="Item" image="arrow.left" catalog="system" id="xGy-Ej-dyo"/>
@@ -40,6 +41,9 @@
         <image name="arrow.right" catalog="system" width="128" height="98"/>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="systemCyanColor">
+            <color red="0.19607843137254902" green="0.67843137254901964" blue="0.90196078431372551" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/DietApp/View/TopPage/TopView.xib
+++ b/DietApp/View/TopPage/TopView.xib
@@ -22,7 +22,7 @@
             <subviews>
                 <navigationBar contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Jn6-ps-dap">
                     <rect key="frame" x="0.0" y="44" width="414" height="44"/>
-                    <color key="backgroundColor" systemColor="systemBlueColor"/>
+                    <color key="backgroundColor" systemColor="systemCyanColor"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="414" id="n3R-7R-3bj"/>
                         <constraint firstAttribute="height" constant="44" id="qqz-rd-yte"/>
@@ -59,8 +59,8 @@
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>
-        <systemColor name="systemBlueColor">
-            <color red="0.0" green="0.47843137254901963" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        <systemColor name="systemCyanColor">
+            <color red="0.19607843137254902" green="0.67843137254901964" blue="0.90196078431372551" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>


### PR DESCRIPTION
close #5 

## issue
#5 
## やったこと
- GraphPageのnavigationBarTitleSetting ()の調整を行い、曜日を削除した。

- GraphViewControllerとTopViewControllerのリファクタリングをした。

**※ navigationBarTitleSetting ()の共有化は行わなかった。** 
## なぜ共有化をしなかったか

- TopとGraphのNaviationBarを比較したとき、text数の違いやそれらに対する処理に違いがあるため。
- それぞれのNavigationBarの仕様を変更するときに、内容、タイミングが異なることが予想されるため。

上記の理由を踏まえたとき、二つのnavigationBarTitleSetting ()を共有化した場合コードが煩雑になり、扱いが難しいメソッドになることが予想されたので、あえて分離して定義することにした。

参考記事
共通パーツはどのように共通化すべきなのか？（UIView）
https://qiita.com/am10/items/78f7735ef0bf11e2bd99

## 変更内容

- GraphPageのNavigationBarのUI

<img width="593" alt="スクリーンショット 2023-06-03 13 25 57" src="https://github.com/MasayukiKawashima/diet-app/assets/82994988/bb481937-0ff1-4cfc-b2f3-62c1bb57763d">

曜日を削除した。

- GraphViewControllerとTopViewControllerのリファクタリング

1. NavigationBarのbackgroudColorの設定をinterfaceBuilderで設定することにした。
2. コメントの追加、不要なコメントの削除

## 振り返り

- 共有化についての判断は妥当かどうか正直自信がないので、今後も意識して学習したい