### PR TITLE
グラフのオートレイアウトの設定をした。

### DIFF
--- a/DietApp/GraphPage/GraphViewController.swift
+++ b/DietApp/GraphPage/GraphViewController.swift
@@ -36,6 +36,12 @@ class GraphViewController: UIViewController {
     }
   }
   
+  var safeAreaRight:CGFloat = CGFloat()
+  var safeAreaLeft:CGFloat = CGFloat()
+  var safeAreaBottom:CGFloat = CGFloat()
+  var safeAreATop:CGFloat = CGFloat()
+  var tabBatController: UITabBarController = TabBarController()
+  
     override func viewDidLoad() {
         super.viewDidLoad()
         // Do any additional setup after loading the view.
@@ -52,7 +58,25 @@ class GraphViewController: UIViewController {
     super.loadView()
     view = graphView
   }
-    /*
+  
+  override func viewWillLayoutSubviews() {
+    super.viewWillLayoutSubviews()
+    
+    if #available(iOS 11.0, *) {
+     
+      safeAreaLeft = self.view.safeAreaInsets.left
+      safeAreaRight = self.view.safeAreaInsets.right
+      safeAreaBottom = self.view.safeAreaInsets.bottom
+      safeAreATop = self.view.safeAreaInsets.top
+      print("あああああ")
+      print(safeAreaLeft)
+      print(safeAreaRight)
+      print(safeAreaBottom)
+      print(safeAreATop)
+      print(tabBatController.tabBar.frame.size.height)
+    }
+    graphViewAutoLayoutSetting()
+  }
     // MARK: - Navigation
 
     // In a storyboard-based application, you will often want to do a little preparation before navigation
@@ -60,7 +84,6 @@ class GraphViewController: UIViewController {
         // Get the new view controller using segue.destination.
         // Pass the selected object to the new view controller.
     }
-    */
 }
 //navigaitonBarの設定
 extension GraphViewController {
@@ -113,6 +136,22 @@ extension GraphViewController {
     graphView.navigationItem.titleView = customTitleView
   }
 }
+
+//graphViewのオートレイアウト設定
+extension GraphViewController {
+  func graphViewAutoLayoutSetting() {
+    let graphView = graphView.graphAreaView
+    graphView?.translatesAutoresizingMaskIntoConstraints = false
+    
+    NSLayoutConstraint.activate([
+    graphView!.topAnchor.constraint(equalTo: self.view.topAnchor, constant:self.tabBatController.tabBar.frame.size.height),    graphView!.leadingAnchor.constraint(equalTo: self.view.leadingAnchor, constant: safeAreaLeft),
+    graphView!.trailingAnchor.constraint(equalTo: self.view.trailingAnchor, constant: -safeAreaRight),
+    graphView!.bottomAnchor.constraint(equalTo: self.view.bottomAnchor, constant: -safeAreaBottom),
+    ])
+    
+  }
+}
+
 //グラフの設定
 extension GraphViewController {
   func graphSetting() {

--- a/DietApp/View/GraphPage/GraphView.swift
+++ b/DietApp/View/GraphPage/GraphView.swift
@@ -14,7 +14,8 @@ class GraphView: UIView {
   
   @IBOutlet weak var navigationItem: UINavigationItem!
   
-  @IBOutlet weak var graphView: LineChartView!
+  @IBOutlet weak var graphAreaView: LineChartView!
+  
   
   override init(frame: CGRect) {
     super.init(frame: frame)

--- a/DietApp/View/GraphPage/GraphView.xib
+++ b/DietApp/View/GraphPage/GraphView.xib
@@ -10,7 +10,7 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="GraphView" customModule="DietApp" customModuleProvider="target">
             <connections>
-                <outlet property="graphView" destination="iBf-lh-5cY" id="sNE-8V-KjX"/>
+                <outlet property="graphAreaView" destination="iBf-lh-5cY" id="wrN-n5-L9Q"/>
                 <outlet property="navigationBar" destination="W5m-cm-4a6" id="pv7-Jz-gRS"/>
                 <outlet property="navigationItem" destination="Kp2-xc-LxT" id="6FP-Ib-wZh"/>
             </connections>
@@ -32,14 +32,14 @@
                     </items>
                 </navigationBar>
                 <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="iBf-lh-5cY" customClass="LineChartView" customModule="Charts">
-                    <rect key="frame" x="60" y="44" width="776" height="264"/>
+                    <rect key="frame" x="290" y="115" width="316" height="184"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                     <color key="backgroundColor" systemColor="systemGray5Color"/>
                 </view>
             </subviews>
             <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
             <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-            <point key="canvasLocation" x="131.91964285714286" y="63.768115942028992"/>
+            <point key="canvasLocation" x="139.28571428571428" y="327.536231884058"/>
         </view>
     </objects>
     <resources>


### PR DESCRIPTION
close #9 

## 概要
グラフのオートレイアウトを設定した。
## やったこと
グラフページのgraphAreaViewのオートレイアウトをコードで実装した。
グラフを表示するViewの名前をgraphView→graphAreaViewに変更した。
## 変更内容
<img width="591" alt="スクリーンショット 2023-06-08 12 56 51" src="https://github.com/MasayukiKawashima/diet-app/assets/82994988/853aa604-e775-41bc-9275-8e6641df3b60">

## タスク

- グラフページ内のtabBarの下にある青の横長の部分を消す。（デバイスによって表示されたり、されなかったりする）

<img width="571" alt="スクリーンショット 2023-06-08 12 53 36" src="https://github.com/MasayukiKawashima/diet-app/assets/82994988/75a29647-7f8c-4239-af75-cbac13086950">

画像はiphone8でビルドしたときのもの
- トップページのオートレイアウト設定の見直し。

## 振り返り

- ある程度構想をしてから調査、実装を行ったらスムーズだった。
実装概要の思考整理、調査と実装に必要なもののリストアップ、フローの構想