### PR TITLE
各ページの実装予定機能のリストアップといくつかの実装、デバッグを行なった。

### DIFF
--- a/DietApp/GraphPage/GraphViewController.swift
+++ b/DietApp/GraphPage/GraphViewController.swift
@@ -141,7 +141,8 @@ extension GraphViewController {
     let rightMargin = safeAreaRight + 5.0
     
     NSLayoutConstraint.activate([
-    graphView!.topAnchor.constraint(equalTo: self.view.topAnchor, constant:self.tabBatController.tabBar.frame.size.height),    graphView!.leadingAnchor.constraint(equalTo: self.view.leadingAnchor, constant: leftMargin),
+    graphView!.topAnchor.constraint(equalTo: self.view.topAnchor, constant:self.tabBatController.tabBar.frame.size.height),
+    graphView!.leadingAnchor.constraint(equalTo: self.view.leadingAnchor, constant: leftMargin),
     graphView!.trailingAnchor.constraint(equalTo: self.view.trailingAnchor, constant: -rightMargin),
     graphView!.bottomAnchor.constraint(equalTo: self.view.bottomAnchor, constant: -bottomMargin),
     ])

--- a/DietApp/GraphPage/GraphViewController.swift
+++ b/DietApp/GraphPage/GraphViewController.swift
@@ -10,7 +10,6 @@ import Charts
 
 class GraphViewController: UIViewController {
   var graphView = GraphView()
-  var tabBatController: UITabBarController = TabBarController()
   
   override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
     //左横画面に変更
@@ -63,13 +62,15 @@ class GraphViewController: UIViewController {
     super.viewWillLayoutSubviews()
     //safeAreaの取得
     if #available(iOS 11.0, *) {
-     
+      
       safeAreaLeft = self.view.safeAreaInsets.left
       safeAreaRight = self.view.safeAreaInsets.right
       safeAreaBottom = self.view.safeAreaInsets.bottom
     }
     graphViewAutoLayoutSetting()
   }
+  
+  
     // MARK: - Navigation
 
     // In a storyboard-based application, you will often want to do a little preparation before navigation
@@ -88,7 +89,7 @@ extension GraphViewController {
     let fontSize: CGFloat = 14.0
     
     // カスタムビューをインスタンス化
-    let customTitleView = UIView(frame: CGRect(x: 0, y: 0, width: 200, height: 44))
+    let customTitleView = UIView(frame: CGRect(x: 0, y: 0, width: 200, height: graphView.navigationBar.frame.size.height))
 
     // UILabelを作成してテキストを設定
     let yearTextLabel = UILabel(frame: CGRect(x: 0, y: 0, width: 100, height: 22))
@@ -130,23 +131,29 @@ extension GraphViewController {
   }
 }
 
+extension GraphViewController {
+  func navigationBarAutoLayoutsetting() {
+    graphView.navigationBar.translatesAutoresizingMaskIntoConstraints = false
+    
+  }
+}
+
 //graphViewのオートレイアウト設定
 extension GraphViewController {
   func graphViewAutoLayoutSetting() {
-    let graphView = graphView.graphAreaView
-    graphView?.translatesAutoresizingMaskIntoConstraints = false
+    graphView.graphAreaView.translatesAutoresizingMaskIntoConstraints = false
     //余白
+    let topMargin = graphView.navigationBar.frame.size.height + 10
     let bottomMargin = safeAreaBottom + 10.0
     let leftMargin = safeAreaLeft + 5.0
     let rightMargin = safeAreaRight + 5.0
     
     NSLayoutConstraint.activate([
-    graphView!.topAnchor.constraint(equalTo: self.view.topAnchor, constant:self.tabBatController.tabBar.frame.size.height),
-    graphView!.leadingAnchor.constraint(equalTo: self.view.leadingAnchor, constant: leftMargin),
-    graphView!.trailingAnchor.constraint(equalTo: self.view.trailingAnchor, constant: -rightMargin),
-    graphView!.bottomAnchor.constraint(equalTo: self.view.bottomAnchor, constant: -bottomMargin),
+      graphView.graphAreaView.topAnchor.constraint(equalTo: self.view.topAnchor, constant: topMargin),
+      graphView.graphAreaView.leadingAnchor.constraint(equalTo: self.view.leadingAnchor, constant: leftMargin),
+      graphView.graphAreaView.trailingAnchor.constraint(equalTo: self.view.trailingAnchor, constant: -rightMargin),
+      graphView.graphAreaView.bottomAnchor.constraint(equalTo: self.view.bottomAnchor, constant: -bottomMargin),
     ])
-    
   }
 }
 

--- a/DietApp/SettingsPage/SettingsViewController.swift
+++ b/DietApp/SettingsPage/SettingsViewController.swift
@@ -11,6 +11,11 @@ class SettingsViewController: UIViewController {
   var settingsView = SettingsView()
   
   var TableViewCellHeight:CGFloat = 60.0
+  //cell周り設定用の列挙体
+  enum SettingPageCell:Int {
+    case themeColorTableViewCell = 0
+    case notificationTableViewCell
+  }
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -44,14 +49,14 @@ class SettingsViewController: UIViewController {
     */
 
 }
-
+//navigationBarの設定
 extension SettingsViewController: UINavigationBarDelegate {
   //navigationBarをステータスバーを覆うように表示
   func position(for bar: UIBarPositioning) -> UIBarPosition {
     return .topAttached
   }
 }
-
+//tableViewの設定
 extension SettingsViewController: UITableViewDelegate,UITableViewDataSource {
   //セル数の設定
   func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
@@ -59,17 +64,21 @@ extension SettingsViewController: UITableViewDelegate,UITableViewDataSource {
   }
   //各セルの内容の設定
   func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-    var cell = UITableViewCell()
     
-    switch indexPath.row {
-    case 0:
-      cell = tableView.dequeueReusableCell(withIdentifier: "ThemeColorTableViewCell", for: indexPath) as! ThemeColorTableViewCell
-    case 1:
-      cell = tableView.dequeueReusableCell(withIdentifier: "NotificationTableViewCell", for: indexPath) as! NotificationTableViewCell
-    default:
-      print("セルの取得に失敗しました")
+    let cell = SettingPageCell(rawValue: indexPath.row)
+    
+    switch (cell)! {
+    case .themeColorTableViewCell:
+      let cell = tableView.dequeueReusableCell(withIdentifier: "ThemeColorTableViewCell", for: indexPath) as! ThemeColorTableViewCell
+      //セルの選択時のハイライトを非表示にする
+      cell.selectionStyle = UITableViewCell.SelectionStyle.none
+      return cell
+      
+    case .notificationTableViewCell:
+      let cell = tableView.dequeueReusableCell(withIdentifier: "NotificationTableViewCell", for: indexPath) as! NotificationTableViewCell
+      cell.selectionStyle = UITableViewCell.SelectionStyle.none
+      return cell
     }
-    return cell
   }
   //セルの高さの推定値の設定
   func tableView(_ tableView: UITableView, estimatedHeightForRowAt indexPath: IndexPath) -> CGFloat {

--- a/DietApp/SettingsPage/SettingsViewController.swift
+++ b/DietApp/SettingsPage/SettingsViewController.swift
@@ -9,6 +9,16 @@ import UIKit
 
 class SettingsViewController: UIViewController {
   var settingsView = SettingsView()
+  //回転を許可するかどうかを決める
+  //デバイスの向きが変更されたときに呼び出される
+  override var shouldAutorotate: Bool {
+    UIDevice.current.setValue(1, forKey: "orientation")
+    return false
+  }
+  
+  override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
+    return .portrait
+  }
   
   var TableViewCellHeight:CGFloat = 60.0
   //cell周り設定用の列挙体

--- a/DietApp/TabBarController.swift
+++ b/DietApp/TabBarController.swift
@@ -11,7 +11,11 @@ class TabBarController: UITabBarController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-      
+      //TabBarの背景色の設定
+      let appearance = UITabBarAppearance()
+      appearance.backgroundColor =  UIColor.systemGray6
+      UITabBar.appearance().standardAppearance = appearance
+      UITabBar.appearance().scrollEdgeAppearance = appearance
         // Do any additional setup after loading the view.
     }
     /*

--- a/DietApp/TopPage/TopViewController.swift
+++ b/DietApp/TopPage/TopViewController.swift
@@ -18,7 +18,7 @@ class TopViewController: UIViewController {
   
   override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
     
-      return .portrait
+    return .portrait
   }
   
   var tabBarHeight: CGFloat {
@@ -44,13 +44,31 @@ class TopViewController: UIViewController {
   }
   var adTableViewCellHeight:CGFloat = 53.0
   
+  //セル周り設定用の列挙体
+  enum TopPageCell: Int {
+    case weightTableViewCell = 0
+    case memoTableViewCell
+    case photoTableViewCell
+    case adTableViewCell
+  }
+  
   override func viewDidLoad() {
-        super.viewDidLoad()
-        // Do any additional setup after loading the view.
+    super.viewDidLoad()
+    // Do any additional setup after loading the view.
     topView.navigationBar.delegate = self
     topView.tableView.delegate = self
     topView.tableView.dataSource = self
-
+    //セルのインスタンスからのデリゲート設定
+//    if let weightCell = topView.tableView.cellForRow(at: IndexPath(row: TopPageCell.weightTableViewCell.rawValue, section: 0)) as? WeightTableViewCell {
+//      weightCell.weightTextField.delegate = self
+//    }
+    //tableViewでタップ認識させるための設定
+    let tapGesture = UITapGestureRecognizer(
+      target: self,
+      action: #selector(dismissKeyboard))
+    tapGesture.cancelsTouchesInView = false
+    view.addGestureRecognizer(tapGesture)
+    
     //スクロールできないようにする
     topView.tableView.isScrollEnabled = false
     //tableViewCellの高さの自動設定
@@ -59,21 +77,21 @@ class TopViewController: UIViewController {
     topView.tableView.separatorStyle = .none
     
     navigationBarTitleSetting()
-    }
-  
+  }
+
   override func loadView() {
     super.loadView()
     view = topView
   }
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
-    }
-    */
+  /*
+   // MARK: - Navigation
+   
+   // In a storyboard-based application, you will often want to do a little preparation before navigation
+   override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+   // Get the new view controller using segue.destination.
+   // Pass the selected object to the new view controller.
+   }
+   */
 }
 
 //navigationBarの設定
@@ -158,54 +176,75 @@ extension TopViewController: UITableViewDelegate,UITableViewDataSource {
   
   //各セルを内容を設定し表示
   func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-    var cell = UITableViewCell()
     
-    switch indexPath.row {
-    case 0:
-      cell = tableView.dequeueReusableCell(withIdentifier: "WeightTableViewCell", for: indexPath) as! WeightTableViewCell
-      
-    case 1:
-      cell = tableView.dequeueReusableCell(withIdentifier: "MemoTableViewCell", for: indexPath) as! MemoTableViewCell
-      
-    case 2:
-      cell = tableView.dequeueReusableCell(withIdentifier: "PhotoTableViewCell", for: indexPath) as! PhotoTableViewCell
+    let cell = TopPageCell(rawValue: indexPath.row)
     
-    case 3:
-      cell = tableView.dequeueReusableCell(withIdentifier: "AdTableViewCell", for: indexPath) as! AdTableViewCell
+    switch (cell)! {
+    case .weightTableViewCell:
+      let cell = tableView.dequeueReusableCell(withIdentifier: "WeightTableViewCell", for: indexPath) as! WeightTableViewCell
+      //セルの選択時のハイライトを非表示にする
+      cell.selectionStyle = UITableViewCell.SelectionStyle.none
+      return cell
       
-    default:
-      print("セルの取得に失敗しました")
+    case .memoTableViewCell:
+      let cell = tableView.dequeueReusableCell(withIdentifier: "MemoTableViewCell", for: indexPath) as! MemoTableViewCell
+      cell.selectionStyle = UITableViewCell.SelectionStyle.none
+      return cell
+      
+    case .photoTableViewCell:
+      let cell = tableView.dequeueReusableCell(withIdentifier: "PhotoTableViewCell", for: indexPath) as! PhotoTableViewCell
+      cell.selectionStyle = UITableViewCell.SelectionStyle.none
+      return cell
+    
+    case .adTableViewCell:
+      let cell = tableView.dequeueReusableCell(withIdentifier: "AdTableViewCell", for: indexPath) as! AdTableViewCell
+      cell.selectionStyle = UITableViewCell.SelectionStyle.none
+      return cell
     }
-    return cell
   }
   //各セルの高さの推定値を設定
   func tableView(_ tableView: UITableView, estimatedHeightForRowAt indexPath: IndexPath) -> CGFloat {
-    switch indexPath.row {
-    case 0:
+    let cell = TopPageCell(rawValue: indexPath.row)
+    
+    switch (cell)! {
+    case .weightTableViewCell:
       return weightTableViewCellHeight
-    case 1:
+      
+    case .memoTableViewCell:
       return memoTableViewCellHeight
-    case 2:
+      
+    case .photoTableViewCell:
       return photoTableViewCellHeight
-    case 3:
+      
+    case .adTableViewCell:
       return adTableViewCellHeight
-    default:
-      return 44.0
     }
   }
   //セルの高さの設定
   func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-    switch indexPath.row {
-    case 0:
+    let cell = TopPageCell(rawValue: indexPath.row)
+    
+    switch (cell)! {
+    case .weightTableViewCell:
       return weightTableViewCellHeight
-    case 1:
+      
+    case .memoTableViewCell:
       return memoTableViewCellHeight
-    case 2:
+      
+    case .photoTableViewCell:
       return photoTableViewCellHeight
-    case 3:
+      
+    case .adTableViewCell:
       return adTableViewCellHeight
-    default:
-      return 44.0
     }
   }
 }
+//UITextField周りの処理
+//エンターを押したらキーボードを閉じる処理
+extension TopViewController {
+  //キーボード以外の領域をタッチしたらキーボードを閉じる処理
+  @objc public func dismissKeyboard() {
+    view.endEditing(true)
+  }
+}
+

--- a/DietApp/View/GraphPage/GraphView.xib
+++ b/DietApp/View/GraphPage/GraphView.xib
@@ -20,10 +20,12 @@
             <rect key="frame" x="0.0" y="0.0" width="896" height="414"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <navigationBar contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="W5m-cm-4a6">
-                    <rect key="frame" x="0.0" y="0.0" width="896" height="44"/>
-                    <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
+                <navigationBar contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="W5m-cm-4a6">
+                    <rect key="frame" x="0.0" y="0.0" width="896" height="32"/>
                     <color key="backgroundColor" systemColor="systemCyanColor"/>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="32" id="uTh-wG-lf8"/>
+                    </constraints>
                     <items>
                         <navigationItem id="Kp2-xc-LxT">
                             <barButtonItem key="leftBarButtonItem" title="Item" image="arrow.left" catalog="system" id="xGy-Ej-dyo"/>
@@ -39,6 +41,11 @@
             </subviews>
             <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
             <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+            <constraints>
+                <constraint firstItem="W5m-cm-4a6" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" id="XHV-Kn-UuY"/>
+                <constraint firstItem="W5m-cm-4a6" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="eQT-iS-9sN"/>
+                <constraint firstAttribute="trailing" secondItem="W5m-cm-4a6" secondAttribute="trailing" id="gtR-5J-Fba"/>
+            </constraints>
             <point key="canvasLocation" x="139.28571428571428" y="327.536231884058"/>
         </view>
     </objects>

--- a/DietApp/View/TopPage/Cell/MemoTableViewCell.swift
+++ b/DietApp/View/TopPage/Cell/MemoTableViewCell.swift
@@ -15,6 +15,8 @@ class MemoTableViewCell: UITableViewCell {
         super.awakeFromNib()
         // Initialization code
     
+    memoTextField.delegate = self
+    
     
     let placeholderText = "ひとことメモ"
     let attributes = [
@@ -33,23 +35,32 @@ class MemoTableViewCell: UITableViewCell {
     
 }
 
-extension UITextField {
-  func setPlaceholder(text: String, systemImageName: String) {
-    let placeholderView = UIView(frame: CGRect(x: 0, y: 0, width: 320, height: 44))
-    
-    let imageView = UIImageView(frame: CGRect(x: 0, y: 0, width: 20, height: 20))
-    imageView.image = UIImage(systemName: systemImageName)
-    imageView.tintColor = .systemGray
-    placeholderView.addSubview(imageView)
-    
-    let label = UILabel(frame: CGRect(x: 25, y: 0, width: 175, height: 44))
-    label.text = text
-    label.textColor = .black
-    label.font = UIFont.systemFont(ofSize: 14.0)
-    placeholderView.addSubview(label)
-    
-    self.placeholder = ""
-    self.leftView = placeholderView
-    self.leftViewMode = .always
+extension MemoTableViewCell: UITextFieldDelegate {
+  func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+    memoTextField.resignFirstResponder()
+    return true
   }
 }
+
+
+//このエクステンションの必要性については後日確認
+//extension UITextField {
+//  func setPlaceholder(text: String, systemImageName: String) {
+//    let placeholderView = UIView(frame: CGRect(x: 0, y: 0, width: 320, height: 44))
+//
+//    let imageView = UIImageView(frame: CGRect(x: 0, y: 0, width: 20, height: 20))
+//    imageView.image = UIImage(systemName: systemImageName)
+//    imageView.tintColor = .systemGray
+//    placeholderView.addSubview(imageView)
+//
+//    let label = UILabel(frame: CGRect(x: 25, y: 0, width: 175, height: 44))
+//    label.text = text
+//    label.textColor = .black
+//    label.font = UIFont.systemFont(ofSize: 14.0)
+//    placeholderView.addSubview(label)
+//
+//    self.placeholder = ""
+//    self.leftView = placeholderView
+//    self.leftViewMode = .always
+//  }
+//}

--- a/DietApp/View/TopPage/Cell/MemoTableViewCell.xib
+++ b/DietApp/View/TopPage/Cell/MemoTableViewCell.xib
@@ -16,7 +16,7 @@
                 <rect key="frame" x="0.0" y="0.0" width="320" height="49"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="RAo-WU-Iqz">
+                    <textField opaque="NO" tag="2" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="RAo-WU-Iqz">
                         <rect key="frame" x="0.0" y="1.5" width="320" height="44"/>
                         <constraints>
                             <constraint firstAttribute="width" constant="320" id="5dZ-R5-0px"/>

--- a/DietApp/View/TopPage/Cell/WeightTableViewCell.swift
+++ b/DietApp/View/TopPage/Cell/WeightTableViewCell.swift
@@ -12,26 +12,55 @@ class WeightTableViewCell: UITableViewCell {
   @IBOutlet weak var weightTextField: UITextField!
   @IBOutlet weak var kgLabel: UILabel!
   
-
-    override func awakeFromNib() {
-        super.awakeFromNib()
-        // Initialization code
-      let placeholderText = "体重を入力"
-      let attributes = [
-          NSAttributedString.Key.font: UIFont.systemFont(ofSize: 14)
-      ]
-      weightTextField.attributedPlaceholder = NSAttributedString(string: placeholderText, attributes: attributes)
-      
-      weightTextField.setUnderLine()
-    }
-
-    override func setSelected(_ selected: Bool, animated: Bool) {
-        super.setSelected(selected, animated: animated)
-
-        // Configure the view for the selected state
-    }
+  override func awakeFromNib() {
+    super.awakeFromNib()
+    // Initialization code
+    weightTextField.delegate = self
+    //キーボードタイプ設定
+    weightTextField.keyboardType = .decimalPad
     
+    let placeholderText = "体重を入力"
+    let attributes = [
+      NSAttributedString.Key.font: UIFont.systemFont(ofSize: 14)
+    ]
+    weightTextField.attributedPlaceholder = NSAttributedString(string: placeholderText, attributes: attributes)
+    
+    weightTextField.setUnderLine()
+    setUpCloseButton()
+  }
+  
+  override func setSelected(_ selected: Bool, animated: Bool) {
+    super.setSelected(selected, animated: animated)
+    // Configure the view for the selected state
+  }
+
 }
+//この設定についてはよう確認
+extension WeightTableViewCell: UITextFieldDelegate {
+  func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+    weightTextField.resignFirstResponder()
+    return true
+  }
+}
+//キーボード上部の閉じるボタンを作成
+extension WeightTableViewCell {
+  func setUpCloseButton() {
+    let toolBar = UIToolbar()
+    toolBar.sizeToFit()
+    //単に新しいTopViewControllerのインスタンスを作るだけで良いのか、現在の最上位のビュー（TopViewContoller)を取得した方が良いのか後日確認
+    let topVC = TopViewController()
+    // スペーサー構築
+    let spacer = UIBarButtonItem(barButtonSystemItem: UIBarButtonItem.SystemItem.flexibleSpace, target: self, action: nil)
+    // 閉じるボタン構築
+    let closeButton = UIBarButtonItem(barButtonSystemItem: UIBarButtonItem.SystemItem.close, target: topVC, action:#selector(TopViewController.dismissKeyboard))
+    
+    toolBar.items = [spacer, closeButton]
+    weightTextField.inputAccessoryView = toolBar
+    // MARK: - 閉じるボタン
+  }
+}
+
+
 //拡張の内容、記述場所は後日検討
 extension UITextField {
   func setUnderLine() {
@@ -45,5 +74,3 @@ extension UITextField {
     bringSubviewToFront(underline)
   }
 }
-
-

--- a/DietApp/View/TopPage/Cell/WeightTableViewCell.xib
+++ b/DietApp/View/TopPage/Cell/WeightTableViewCell.xib
@@ -16,7 +16,7 @@
                 <rect key="frame" x="0.0" y="0.0" width="320" height="70"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="6Z2-CE-98M">
+                    <textField opaque="NO" tag="1" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="6Z2-CE-98M">
                         <rect key="frame" x="60" y="1.5" width="200" height="67"/>
                         <constraints>
                             <constraint firstAttribute="width" constant="200" id="DMO-2g-wKH"/>


### PR DESCRIPTION
## issue
close #17 
## 概要
今後実装するべき機能をリストアップとそれを行うためにいくつかの機能とデバッグを実装した。
## リストアップの内容
**Topページ**

- NavigtionBarのカスタムタイトルの設定
- 体重セルの入力制御、DB周りの設定
- メモセルの入力制御、DB周りの設定
- 写真セルの写真挿入機能（UIImagePickerController)、選択後の処理（やりなおし機能等)の設定
- 広告セルの設定
- pagingの設定

**Graphページ**

- NavigtionBarのカスタムタイトルの設定
- XとY軸の設定
- DBへのアクセス、エントリーポイントの作成
- エントリーポイントのハイライト、データの表示設定
- pagingの設定

**Settingsページ**

- テーマカラーの変更設定
- 通知の設定

## 実装内容
**TabBar**

- TabBar内の背景色を薄いグレーに設定。
![スクリーンショット 2023-06-16 19 33 58](https://github.com/MasayukiKawashima/diet-app/assets/82994988/94cc1272-2472-4e9e-92e9-6be1378a2b32)

**Topページ**

- 体重セルとメモセルのTextFieldのタップ時のキーパッドを閉じることができるようにした。
→キーパッド以外の領域のタップ時、エンターキー押下時、キーボード上のツールバー内閉じるボタンの表示。
![スクリーンショット 2023-06-16 19 24 02](https://github.com/MasayukiKawashima/diet-app/assets/82994988/16036416-3b9d-4a02-9c79-dfb1f5bbe503)

- 体重セルのキーパッドを数字＋小数点のキーパッドに変更した。
- 上記機能の実装のため、tableView内のタップを感知できるようにした。
- セルの選択時のハイライトを非表示にした。

**Settingsページ**

- Settingsページの画面の向きの設定
→画面遷移時の縦方向への回転及びこの機能以外で画面回転しないようにした。

## デバッグ内容

**Graphページ内のNavigationBarとGraphAreaViewとの間の青い余白を取り除いた。**

- バグの内容
iPhone８やSEなど比較的画面サイズが小さいデバイスでシミュレーターを起動したら、Graphページ内のNavigationBarとGraphAreaViewとの間の青い余白が表示されている。iPhone11等の他のデバイスではこのような現象は起きていない。

- 修正結果
修正前
![スクリーンショット 2023-06-14 12 52 48 4](https://github.com/MasayukiKawashima/diet-app/assets/82994988/48f2bc40-4457-4acc-856a-882a9504d11f)
修正後
![スクリーンショット 2023-06-16 19 41 08](https://github.com/MasayukiKawashima/diet-app/assets/82994988/58e1c9fb-c5f2-4081-801f-45086b5c5128)
- バグの原因
NavigationBarとそれに乗っかっている各Viewとの高さに違いがあったため。（NavigationBarの高さ44pt、各Viewの高さ32pt）
- バグの修正方法
Graphページ内のNavigationBarの高さを32ptにした。

## 今後のタスク

- 上記のリストの機能の実装。
- 各ページのレイアウトの調整。
- デバックエリアのメッセージの確認。

## 振り返り

- 想定していたよりも時間がかかった。
- View関係のデバックの際にはビューデバッガーを利用してみる。
