### PR TITLE
ログの警告の確認とAutoLayoutの修正

### DIFF
--- a/DietApp/GraphPage/GraphViewController.swift
+++ b/DietApp/GraphPage/GraphViewController.swift
@@ -25,6 +25,8 @@ class GraphViewController: UIViewController {
     }
   }
   
+
+  
   // 画面を自動で回転させるかを決定する。
   override var shouldAutorotate: Bool {
     //画面が縦だった場合は回転させない
@@ -58,18 +60,31 @@ class GraphViewController: UIViewController {
     view = graphView
   }
   
-  override func viewWillLayoutSubviews() {
-    super.viewWillLayoutSubviews()
-    //safeAreaの取得
+//  override func viewWillLayoutSubviews() {
+//    super.viewWillLayoutSubviews()
+//    //safeAreaの取得
+//    if #available(iOS 11.0, *) {
+//
+//      safeAreaLeft = self.view.safeAreaInsets.left
+//      safeAreaRight = self.view.safeAreaInsets.right
+//      safeAreaBottom = self.view.safeAreaInsets.bottom
+//    }
+//    graphAreaViewAutoLayoutSetting()
+//  }
+  
+  override func viewDidLayoutSubviews() {
+    super.viewDidLayoutSubviews()
+    _ = self.initViewLayout
+  }
+  private lazy var initViewLayout : Void = {
+      print(self.view.frame)
     if #available(iOS 11.0, *) {
-      
       safeAreaLeft = self.view.safeAreaInsets.left
       safeAreaRight = self.view.safeAreaInsets.right
       safeAreaBottom = self.view.safeAreaInsets.bottom
     }
-    graphViewAutoLayoutSetting()
-  }
-  
+    graphAreaViewAutoLayoutSetting()
+  }()
   
     // MARK: - Navigation
 
@@ -140,13 +155,15 @@ extension GraphViewController {
 
 //graphViewのオートレイアウト設定
 extension GraphViewController {
-  func graphViewAutoLayoutSetting() {
+  func graphAreaViewAutoLayoutSetting() {
     graphView.graphAreaView.translatesAutoresizingMaskIntoConstraints = false
     //余白
     let topMargin = graphView.navigationBar.frame.size.height + 10
     let bottomMargin = safeAreaBottom + 10.0
     let leftMargin = safeAreaLeft + 5.0
     let rightMargin = safeAreaRight + 5.0
+    
+    NSLayoutConstraint.deactivate(graphView.graphAreaView.constraints)
     
     NSLayoutConstraint.activate([
       graphView.graphAreaView.topAnchor.constraint(equalTo: self.view.topAnchor, constant: topMargin),

--- a/DietApp/SettingsPage/SettingsViewController.swift
+++ b/DietApp/SettingsPage/SettingsViewController.swift
@@ -42,6 +42,8 @@ class SettingsViewController: UIViewController {
       settingsView.tableView.isScrollEnabled = false
       //セルの高さの自動設定
       settingsView.tableView.rowHeight = UITableView.automaticDimension
+      
+      navigationBarTittleSettings()
     }
   
   override func loadView() {
@@ -97,5 +99,30 @@ extension SettingsViewController: UITableViewDelegate,UITableViewDataSource {
   //セルの高さを設定
   func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
     return TableViewCellHeight
+  }
+}
+
+extension SettingsViewController {
+  func navigationBarTittleSettings() {
+    
+    let titleText = "設定"
+    
+    let customTitleView = UIView(frame: CGRect(x: 0, y: 0, width: 200, height: settingsView.navigationBar.frame.size.height))
+    
+    let titleTextLabel = UILabel(frame: CGRect(x: 0, y: 0, width: 100, height: 22))
+    titleTextLabel.text = titleText
+    titleTextLabel.font = UIFont(name: "Thonburi-Bold", size: 18.0)
+    titleTextLabel.textColor = .black
+    titleTextLabel.sizeToFit()
+    
+    titleTextLabel.translatesAutoresizingMaskIntoConstraints = false
+    
+    customTitleView.addSubview(titleTextLabel)
+    
+    NSLayoutConstraint.activate([
+      titleTextLabel.centerXAnchor.constraint(equalTo: customTitleView.centerXAnchor),
+      titleTextLabel.centerYAnchor.constraint(equalTo: customTitleView.centerYAnchor)
+    ])
+    settingsView.navigationItem.titleView = customTitleView
   }
 }

--- a/DietApp/View/GraphPage/GraphView.xib
+++ b/DietApp/View/GraphPage/GraphView.xib
@@ -24,7 +24,7 @@
                     <rect key="frame" x="0.0" y="0.0" width="896" height="32"/>
                     <color key="backgroundColor" systemColor="systemCyanColor"/>
                     <constraints>
-                        <constraint firstAttribute="height" constant="32" id="uTh-wG-lf8"/>
+                        <constraint firstAttribute="height" constant="32" id="Ryy-IW-jge"/>
                     </constraints>
                     <items>
                         <navigationItem id="Kp2-xc-LxT">
@@ -42,9 +42,9 @@
             <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
             <color key="backgroundColor" systemColor="systemBackgroundColor"/>
             <constraints>
-                <constraint firstItem="W5m-cm-4a6" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" id="XHV-Kn-UuY"/>
-                <constraint firstItem="W5m-cm-4a6" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="eQT-iS-9sN"/>
-                <constraint firstAttribute="trailing" secondItem="W5m-cm-4a6" secondAttribute="trailing" id="gtR-5J-Fba"/>
+                <constraint firstItem="W5m-cm-4a6" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="ASD-48-TkP"/>
+                <constraint firstAttribute="trailing" secondItem="W5m-cm-4a6" secondAttribute="trailing" id="QAf-ZF-I80"/>
+                <constraint firstItem="W5m-cm-4a6" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" id="UqD-Ch-tvS"/>
             </constraints>
             <point key="canvasLocation" x="139.28571428571428" y="327.536231884058"/>
         </view>

--- a/DietApp/View/SettingsPage/SettingsView.xib
+++ b/DietApp/View/SettingsPage/SettingsView.xib
@@ -23,6 +23,9 @@
                 <navigationBar contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="1q1-rg-XQX">
                     <rect key="frame" x="0.0" y="44" width="414" height="44"/>
                     <color key="backgroundColor" systemColor="systemCyanColor"/>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="44" id="eeW-iL-Gmv"/>
+                    </constraints>
                     <items>
                         <navigationItem title="設定" id="XNq-DC-Uj1"/>
                     </items>
@@ -35,13 +38,13 @@
             <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
             <color key="backgroundColor" systemColor="systemBackgroundColor"/>
             <constraints>
-                <constraint firstItem="1q1-rg-XQX" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" id="0Iz-RR-Qfz"/>
-                <constraint firstItem="RmB-YX-ePb" firstAttribute="top" secondItem="1q1-rg-XQX" secondAttribute="bottom" id="Cxb-yW-i7D"/>
-                <constraint firstItem="RmB-YX-ePb" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" id="IC9-Lb-e9Z"/>
-                <constraint firstItem="1q1-rg-XQX" firstAttribute="trailing" secondItem="vUN-kp-3ea" secondAttribute="trailing" id="gdz-Fv-RuA"/>
-                <constraint firstItem="RmB-YX-ePb" firstAttribute="trailing" secondItem="vUN-kp-3ea" secondAttribute="trailing" id="m1y-gw-86L"/>
-                <constraint firstItem="RmB-YX-ePb" firstAttribute="bottom" secondItem="vUN-kp-3ea" secondAttribute="bottom" id="nij-Do-HMv"/>
-                <constraint firstItem="1q1-rg-XQX" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" id="qym-rO-s9H"/>
+                <constraint firstItem="RmB-YX-ePb" firstAttribute="top" secondItem="1q1-rg-XQX" secondAttribute="bottom" id="2XU-Us-FsM"/>
+                <constraint firstItem="1q1-rg-XQX" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" id="5oo-UX-U6y"/>
+                <constraint firstItem="RmB-YX-ePb" firstAttribute="bottom" secondItem="vUN-kp-3ea" secondAttribute="bottom" id="BPL-Gq-gCe"/>
+                <constraint firstItem="1q1-rg-XQX" firstAttribute="trailing" secondItem="vUN-kp-3ea" secondAttribute="trailing" id="QJ7-jW-uHD"/>
+                <constraint firstItem="RmB-YX-ePb" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" id="SC0-8T-Q0k"/>
+                <constraint firstItem="1q1-rg-XQX" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" id="ljJ-12-mq8"/>
+                <constraint firstItem="RmB-YX-ePb" firstAttribute="trailing" secondItem="vUN-kp-3ea" secondAttribute="trailing" id="m82-KN-aSU"/>
             </constraints>
             <point key="canvasLocation" x="131.8840579710145" y="48.883928571428569"/>
         </view>

--- a/DietApp/View/TopPage/Cell/AdTableViewCell.xib
+++ b/DietApp/View/TopPage/Cell/AdTableViewCell.xib
@@ -20,9 +20,6 @@
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="cjB-mt-U66">
                         <rect key="frame" x="0.0" y="1.5" width="320" height="52"/>
                         <color key="backgroundColor" systemColor="systemCyanColor"/>
-                        <constraints>
-                            <constraint firstAttribute="width" constant="320" id="7dg-8Z-bfN"/>
-                        </constraints>
                     </view>
                 </subviews>
                 <constraints>

--- a/DietApp/View/TopPage/Cell/MemoTableViewCell.xib
+++ b/DietApp/View/TopPage/Cell/MemoTableViewCell.xib
@@ -19,7 +19,6 @@
                     <textField opaque="NO" tag="2" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="RAo-WU-Iqz">
                         <rect key="frame" x="0.0" y="1.5" width="320" height="44"/>
                         <constraints>
-                            <constraint firstAttribute="width" constant="320" id="5dZ-R5-0px"/>
                             <constraint firstAttribute="height" constant="44" id="omV-PN-WhC"/>
                         </constraints>
                         <fontDescription key="fontDescription" type="system" pointSize="14"/>

--- a/DietApp/View/TopPage/TopView.xib
+++ b/DietApp/View/TopPage/TopView.xib
@@ -24,7 +24,6 @@
                     <rect key="frame" x="0.0" y="44" width="414" height="44"/>
                     <color key="backgroundColor" systemColor="systemCyanColor"/>
                     <constraints>
-                        <constraint firstAttribute="width" constant="414" id="n3R-7R-3bj"/>
                         <constraint firstAttribute="height" constant="44" id="qqz-rd-yte"/>
                     </constraints>
                     <items>


### PR DESCRIPTION
## issue
close #19 
## 概要
ログに表示されている警告の確認と修正をおこなった。
内容は主にAutoLayoutに関するものであり、以下に内容と修正方法を記す。
## 警告の内容と修正方法

**1.TopページのmemoセルのAutoLayout**

2023-06-18 12:38:34.468546+0900 DietApp[5716:265035] [LayoutConstraints] Unable to simultaneously satisfy constraints.
	Probably at least one of the constraints in the following list is one you don't want. 
	Try this: 
		(1) look at each constraint and try to figure out which you don't expect; 
		(2) find the code that added the unwanted constraint or constraints and fix it. 
(
    "<NSLayoutConstraint:0x60000210e260 UITextField:0x7f843504c400.width == 320   (active)>",
    "<NSLayoutConstraint:0x60000213c190 H:|-(0)-[UITextField:0x7f843504c400]   (active, names: '|':UITableViewCellContentView:0x7f8436a0f300 )>",
    "<NSLayoutConstraint:0x60000213c1e0 H:[UITextField:0x7f843504c400]-(0)-|   (active, names: '|':UITableViewCellContentView:0x7f8436a0f300 )>",
    "<NSLayoutConstraint:0x6000021337a0 'UIView-Encapsulated-Layout-Width' UITableViewCellContentView:0x7f8436a0f300.width == 414   (active)>"
)

Will attempt to recover by breaking constraint 
<NSLayoutConstraint:0x60000210e260 UITextField:0x7f843504c400.width == 320   (active)>

Make a symbolic breakpoint at UIViewAlertForUnsatisfiableConstraints to catch this in the debugger.
The methods in the UIConstraintBasedLayoutDebugging category on UIView listed in <UIKitCore/UIView.h> may also be helpful.

**修正方法**
memoTableViewCellのtextFieldのwidthの制約を削除した。

**2. Topページの広告セルのAutoLayout**

2023-06-18 12:38:34.501932+0900 DietApp[5716:265035] [LayoutConstraints] Unable to simultaneously satisfy constraints.
	Probably at least one of the constraints in the following list is one you don't want. 
	Try this: 
		(1) look at each constraint and try to figure out which you don't expect; 
		(2) find the code that added the unwanted constraint or constraints and fix it. 
(
    "<NSLayoutConstraint:0x60000210e670 UIView:0x7f8436a12c80.width == 320   (active)>",
    "<NSLayoutConstraint:0x60000210e8a0 H:|-(0)-[UIView:0x7f8436a12c80]   (active, names: '|':UITableViewCellContentView:0x7f8436a11460 )>",
    "<NSLayoutConstraint:0x60000210e8f0 H:[UIView:0x7f8436a12c80]-(0)-|   (active, names: '|':UITableViewCellContentView:0x7f8436a11460 )>",
    "<NSLayoutConstraint:0x60000210ebc0 'UIView-Encapsulated-Layout-Width' UITableViewCellContentView:0x7f8436a11460.width == 414   (active)>"
)

Will attempt to recover by breaking constraint 
<NSLayoutConstraint:0x60000210e670 UIView:0x7f8436a12c80.width == 320   (active)>

Make a symbolic breakpoint at UIViewAlertForUnsatisfiableConstraints to catch this in the debugger.
The methods in the UIConstraintBasedLayoutDebugging category on UIView listed in <UIKitCore/UIView.h> may also be helpful.

**修正方法**
adTableViewCellのviewのwidthの制約を削除

**3. TopページのNavigationBarのAutoLayout**

2023-06-18 13:18:41.700405+0900 DietApp[632:39487] [LayoutConstraints] Unable to simultaneously satisfy constraints.
	Probably at least one of the constraints in the following list is one you don't want. 
	Try this: 
		(1) look at each constraint and try to figure out which you don't expect; 
		(2) find the code that added the unwanted constraint or constraints and fix it. 
	(Note: If you're seeing NSAutoresizingMaskLayoutConstraints that you don't understand, refer to the documentation for the UIView property translatesAutoresizingMaskIntoConstraints) 
(
    "<NSAutoresizingMaskLayoutConstraint:0x2825dcb40 h=-&- v=-&- UIView:0x119e35670.minX == 0   (active, names: '|':DietApp.TopView:0x119e2c470 )>",
    "<NSAutoresizingMaskLayoutConstraint:0x2825dcb90 h=-&- v=-&- H:[UIView:0x119e35670]-(0)-|   (active, names: '|':DietApp.TopView:0x119e2c470 )>",
    "<NSLayoutConstraint:0x2825e6760 UINavigationBar:0x119e2f570.width == 414   (active)>",
    "<NSLayoutConstraint:0x2825e7f20 UINavigationBar:0x119e2f570.centerX == UIView:0x119e35670.centerX   (active)>",
    "<NSLayoutConstraint:0x2825e00f0 UINavigationBar:0x119e2f570.leading == UILayoutGuide:0x283ff97a0'UIViewSafeAreaLayoutGuide'.leading   (active)>",
    "<NSLayoutConstraint:0x2825dcc80 'UIView-Encapsulated-Layout-Width' DietApp.TopView:0x119e2c470.width == 375   (active)>",
    "<NSLayoutConstraint:0x2825e0000 'UIViewSafeAreaLayoutGuide-left' H:|-(0)-[UILayoutGuide:0x283ff97a0'UIViewSafeAreaLayoutGuide'](LTR)   (active, names: '|':UIView:0x119e35670 )>"
)

Will attempt to recover by breaking constraint 
<NSLayoutConstraint:0x2825e6760 UINavigationBar:0x119e2f570.width == 414   (active)>

Make a symbolic breakpoint at UIViewAlertForUnsatisfiableConstraints to catch this in the debugger.
The methods in the UIConstraintBasedLayoutDebugging category on UIView listed in <UIKitCore/UIView.h> may also be helpful.

**修正方法**
NavigationBarのwidthの制約を削除

**4. GraphページのgraphAreaViewのbottomのオートレイアウト**

2023-06-18 13:32:54.080614+0900 DietApp[639:41277] [LayoutConstraints] Unable to simultaneously satisfy constraints.
	Probably at least one of the constraints in the following list is one you don't want. 
	Try this: 
		(1) look at each constraint and try to figure out which you don't expect; 
		(2) find the code that added the unwanted constraint or constraints and fix it. 
(
    "<NSLayoutConstraint:0x281e6fc00 Charts.LineChartView:0x105a05190.bottom == DietApp.GraphView:0x105d0af60.bottom - 59   (active)>",
    "<NSLayoutConstraint:0x281e645a0 Charts.LineChartView:0x105a05190.bottom == DietApp.GraphView:0x105d0af60.bottom - 42   (active)>"
)

Will attempt to recover by breaking constraint 
<NSLayoutConstraint:0x281e645a0 Charts.LineChartView:0x105a05190.bottom == DietApp.GraphView:0x105d0af60.bottom - 42   (active)>

Make a symbolic breakpoint at UIViewAlertForUnsatisfiableConstraints to catch this in the debugger.

**修正方法**
以下のコードを追加した。

  override func viewDidLayoutSubviews() {
    super.viewDidLayoutSubviews()
    _ = self.initViewLayout
  }
  private lazy var initViewLayout : Void = {
      print(self.view.frame)
    if #available(iOS 11.0, *) {
      safeAreaLeft = self.view.safeAreaInsets.left
      safeAreaRight = self.view.safeAreaInsets.right
      safeAreaBottom = self.view.safeAreaInsets.bottom
    }
    graphAreaViewAutoLayoutSetting()
  }()

graphAreaViewのbottomの制約を二重に設定しようとしていることが原因で、AutoLayout設定の関数を実行するタイミングをviewWillLayoutSubviews(_:)からviewDidLayoutSubviews()に変更し、初回のみ呼ばれるようにした。

**5. settingsページのNavigationBarのTitleのAutoLayout**

2023-06-18 17:02:46.946828+0900 DietApp[832:97627] [LayoutConstraints] Unable to simultaneously satisfy constraints.
	Probably at least one of the constraints in the following list is one you don't want. 
	Try this: 
		(1) look at each constraint and try to figure out which you don't expect; 
		(2) find the code that added the unwanted constraint or constraints and fix it. 
(
    "<NSLayoutConstraint:0x283925ef0 _UINavigationBarTitleControl:0x105e45290'\U8a2d\U5b9a'.top >= UILayoutGuide:0x282308620'TitleViewGuide(0x105d11d10)'.top   (active)>",
    "<NSLayoutConstraint:0x2839263a0 _UINavigationBarTitleControl:0x105e45290'\U8a2d\U5b9a'.firstBaseline == UILayoutGuide:0x282308620'TitleViewGuide(0x105d11d10)'.top + 21   (active)>",
    "<NSLayoutConstraint:0x2839268a0 V:|-(0)-[UILabel:0x105e47790]   (active, names: '|':_UINavigationBarTitleControl:0x105e45290'\U8a2d\U5b9a' )>"
)

Will attempt to recover by breaking constraint 
<NSLayoutConstraint:0x2839268a0 V:|-(0)-[UILabel:0x105e47790]   (active, names: '|':_UINavigationBarTitleControl:0x105e45290'設定' )>

Make a symbolic breakpoint at UIViewAlertForUnsatisfiableConstraints to catch this in the debugger.
The methods in the UIConstraintBasedLayoutDebugging category on UIView listed in <UIKitCore/UIView.h> may also be helpful.

**修正方法**
NavigationBarのtitleをカスタムビューとしてコードで実装

## 修正しなかった警告

**Graphページの画面回転に関する警告**

2023-06-18 13:32:54.029799+0900 DietApp[639:41277] [Orientation] BUG IN CLIENT OF UIKIT: Setting UIDevice.orientation is not supported. Please use UIWindowScene.requestGeometryUpdate(_:)
2023-06-18 13:32:54.030891+0900 DietApp[639:41277] [Orientation] BUG IN CLIENT OF UIKIT: Setting UIDevice.orientation is not supported. Please use UIWindowScene.requestGeometryUpdate(_:)
UIInterfaceOrientationMask(rawValue: 8)
2023-06-18 13:32:54.048903+0900 DietApp[639:41277] [Orientation] BUG IN CLIENT OF UIKIT: Setting UIDevice.orientation is not supported. Please use UIWindowScene.requestGeometryUpdate(_:)
2023-06-18 13:32:54.049281+0900 DietApp[639:41277] [Orientation] BUG IN CLIENT OF UIKIT: Setting UIDevice.orientation is not supported. Please use UIWindowScene.requestGeometryUpdate(_:)
2023-06-18 13:32:54.050443+0900 DietApp[639:41277] [Orientation] BUG IN CLIENT OF UIKIT: Setting UIDevice.orientation is not supported. Please use UIWindowScene.requestGeometryUpdate(_:)
2023-06-18 13:32:54.072999+0900 DietApp[639:41277] [Orientation] BUG IN CLIENT OF UIKIT: Setting UIDevice.orientation is not supported. Please use UIWindowScene.requestGeometryUpdate(_:)
2023-06-18 13:32:54.073156+0900 DietApp[639:41277] [Orientation] BUG IN CLIENT OF UIKIT: Setting UIDevice.orientation is not supported. Please use UIWindowScene.requestGeometryUpdate(_:)
2023-06-18 13:32:54.073272+0900 DietApp[639:41277] [Orientation] BUG IN CLIENT OF UIKIT: Setting UIDevice.orientation is not supported. Please use UIWindowScene.requestGeometryUpdate(_:)
2023-06-18 13:32:54.073381+0900 DietApp[639:41277] [Orientation] BUG IN CLIENT OF UIKIT: Setting UIDevice.orientation is not supported. Please use UIWindowScene.requestGeometryUpdate(_:)
2023-06-18 13:32:54.073487+0900 DietApp[639:41277] [Orientation] BUG IN CLIENT OF UIKIT: Setting UIDevice.orientation is not supported. Please use UIWindowScene.requestGeometryUpdate(_:)
2023-06-18 13:32:54.073605+0900 DietApp[639:41277] [Orientation] BUG IN CLIENT OF UIKIT: Setting UIDevice.orientation is not supported. Please use UIWindowScene.requestGeometryUpdate(_:)

**原因**
UIDevice.orientationを使用しているため。

UIWindowScene.requestGeometryUpdate(_:)を使用すれば良いのだが、使用方法の調査に時間がかかりそうなので一旦保留する。

## 振り返り

- デバッカーをうまく使えるようになりたい。
- AutoLayout設定時に無駄な制約を追加しないようにしたい。