### PR TITLE
Topページのpaging（スワイプ時のみ）実装 

### DIFF
--- a/DietApp/TopPage/TopPageViewController.swift
+++ b/DietApp/TopPage/TopPageViewController.swift
@@ -27,8 +27,8 @@ class TopPageViewController: UIPageViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
       
+      self.dataSource = self
       self.initTopPageViewContoller()
-
         // Do any additional setup after loading the view.
     }
   
@@ -38,23 +38,43 @@ class TopPageViewController: UIPageViewController {
     self.controllers = [topVC]
     
     setViewControllers([self.controllers[0]], direction: .forward, animated: true, completion: nil)
-    
-    self.dataSource = self
   }
 }
+
 //PageViewContollerの内容の設定
 extension TopPageViewController: UIPageViewControllerDataSource {
+  enum Direction {
+    case previous
+    case next
+  }
+  
+  func instantiate(direction: Direction) -> TopViewController? {
+    let currentVC = self.viewControllers![0] as! TopViewController
+    let VC = storyboard?.instantiateViewController(withIdentifier: "TopVC") as! TopViewController
+    
+    switch direction {
+    case .previous:
+      let nextIndex = currentVC.pageIndex - 1
+      VC.pageIndex = nextIndex
+      return VC
+    case .next:
+      let nextIndex = currentVC.pageIndex + 1
+      VC.pageIndex = nextIndex
+      return VC
+    }
+  }
+  
   func presentationCount(for pageViewController: UIPageViewController) -> Int {
     return self.controllers.count
   }
   
   //2023.5.23スワイプ時処理は保留
   func pageViewController(_ pageViewController: UIPageViewController, viewControllerBefore viewController: UIViewController) -> UIViewController? {
-    return nil
+    return instantiate(direction: .next)
   }
   
   func pageViewController(_ pageViewController: UIPageViewController, viewControllerAfter viewController: UIViewController) -> UIViewController? {
-    return nil
+    return instantiate(direction: .previous)
   }
   
 }

--- a/DietApp/TopPage/TopViewController.swift
+++ b/DietApp/TopPage/TopViewController.swift
@@ -51,6 +51,8 @@ class TopViewController: UIViewController {
     case photoTableViewCell
     case adTableViewCell
   }
+  //pagingに使うプロパティ
+  var pageIndex: Int = 0
   
   override func viewDidLoad() {
     super.viewDidLoad()


### PR DESCRIPTION
## issue
close #21

## やったこと
Topページのpaging機能（**スワイプ時のみ**）の実装 を行った。
NavigationBar内のボタンによるpaging機能は保留した。

## 保留理由
**結論**
NavigationControllerを実装するため、NavigationBar内のボタンによるpaging機能はそれまで保留する。

**理由**
paging時にNavigationBarごと遷移するような見た目になっており、これは期待した動きではない。
遷移時にNavigationBarを固定させるためNavigationControllerを実装する。

## 振り返り

- NavigationBarに関する使用設計の見当違いをしてしまった。
NavigationBar単体で使用することは珍しいということは把握していたが、その理由をもうすこし調査しても良かったかもしれない。

