### PR TITLE
GraphPageの画面回転バグとAutoLayoutの修正完了

### DIFF
--- a/DietApp/GraphPage/GraphPageViewController.swift
+++ b/DietApp/GraphPage/GraphPageViewController.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 class GraphPageViewController: UIPageViewController {
-  private var controllers: [UIViewController] = []
+  private var controllers: [UIViewController] = [GraphViewController()]
   
   override var shouldAutorotate: Bool {
     if let VC = controllers.first {
@@ -22,7 +22,8 @@ class GraphPageViewController: UIPageViewController {
     if let VC = controllers.first {
       return VC.supportedInterfaceOrientations
     }else{
-      return .landscapeLeft
+
+      return .landscapeRight
     }
   }
   

--- a/DietApp/GraphPage/GraphViewController.swift
+++ b/DietApp/GraphPage/GraphViewController.swift
@@ -17,9 +17,10 @@ class GraphViewController: UIViewController {
       UIDevice.current.setValue(4, forKey: "orientation")
       return .landscapeLeft
     }
-    //左横画面以外の処理
     else {
+      //左横画面以外の処理
       //最初の画面呼び出しで画面を右横画面に変更させる。
+      
       UIDevice.current.setValue(3, forKey: "orientation")
       return .landscapeRight
     }
@@ -46,6 +47,7 @@ class GraphViewController: UIViewController {
       UIDevice.current.setValue(4, forKey: "orientation")
       //画面の向きを変更させるために呼び出す。
       print(supportedInterfaceOrientations)
+
       
 //      navigationBarTitleSetting()
       
@@ -201,4 +203,3 @@ extension GraphViewController {
     graphView.graphAreaView.xAxis.spaceMax = 0.5
   }
 }
-

--- a/DietApp/TopPage/NavigationController+Orientation.swift
+++ b/DietApp/TopPage/NavigationController+Orientation.swift
@@ -13,10 +13,10 @@ extension UINavigationController {
     if let vc = viewControllers.last {
       return vc.shouldAutorotate
     } else {
-      return false
+      return true
     }
   }
-  
+
   open override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
     if let vc = viewControllers.last {
       return vc.supportedInterfaceOrientations

--- a/DietApp/TopPage/TopPageViewController.swift
+++ b/DietApp/TopPage/TopPageViewController.swift
@@ -11,15 +11,15 @@ class TopPageViewController: UIPageViewController {
   private var controllers: [UIViewController] = []
   
   override var shouldAutorotate: Bool {
-    if let VC = controllers.first {
-      return VC.shouldAutorotate
+    if let vc = controllers.first {
+      return vc.shouldAutorotate
     }
     return false
   }
   
   override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
-    if let VC = controllers.first {
-      return VC.supportedInterfaceOrientations
+    if let vc = controllers.first {
+      return vc.supportedInterfaceOrientations
     }
     return .portrait
   }

--- a/DietApp/View/Base.lproj/Main.storyboard
+++ b/DietApp/View/Base.lproj/Main.storyboard
@@ -120,7 +120,7 @@
         <!--グラフ-->
         <scene sceneID="kiP-6u-ge3">
             <objects>
-                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="0pI-mw-1KE" sceneMemberID="viewController">
+                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="0pI-mw-1KE" customClass="GraphNavigationController" customModule="DietApp" customModuleProvider="target" sceneMemberID="viewController">
                     <tabBarItem key="tabBarItem" title="グラフ" image="chart.xyaxis.line" catalog="system" id="qx3-1w-E1q"/>
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="Ml3-ha-DEn">

--- a/DietApp/View/GraphPage/GraphView.xib
+++ b/DietApp/View/GraphPage/GraphView.xib
@@ -19,17 +19,17 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="iBf-lh-5cY" customClass="LineChartView" customModule="Charts">
-                    <rect key="frame" x="60" y="0.0" width="776" height="393"/>
+                    <rect key="frame" x="60" y="20" width="776" height="363"/>
                     <color key="backgroundColor" systemColor="systemGray5Color"/>
                 </view>
             </subviews>
             <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
             <color key="backgroundColor" systemColor="systemBackgroundColor"/>
             <constraints>
-                <constraint firstItem="iBf-lh-5cY" firstAttribute="bottom" secondItem="vUN-kp-3ea" secondAttribute="bottom" id="GVN-UK-wMK"/>
-                <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="iBf-lh-5cY" secondAttribute="trailing" constant="16" id="KpP-z0-BYV"/>
-                <constraint firstItem="iBf-lh-5cY" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" id="Qnj-Pc-a5a"/>
-                <constraint firstItem="iBf-lh-5cY" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" constant="16" id="r3n-jj-bRl"/>
+                <constraint firstItem="iBf-lh-5cY" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" constant="16" id="3UY-4p-Qdq"/>
+                <constraint firstItem="iBf-lh-5cY" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" constant="20" id="Bfv-jd-VKc"/>
+                <constraint firstItem="vUN-kp-3ea" firstAttribute="bottom" secondItem="iBf-lh-5cY" secondAttribute="bottom" constant="10" id="c6X-W6-aIu"/>
+                <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="iBf-lh-5cY" secondAttribute="trailing" constant="16" id="xud-pX-6kQ"/>
             </constraints>
             <point key="canvasLocation" x="139.28571428571428" y="327.536231884058"/>
         </view>


### PR DESCRIPTION
## issue
close #25 

## 概要

- GraphPageへの画面遷移時の画面が一瞬上下逆になる現象を修正。
- graphAreaViewのAutoLayoutの修正

## 内容

**GraphPageへの画面遷移時の画面が一瞬上下逆になる現象を修正。**
TabBarControllerからGraphViewControllrerまでのsupportedInterfaceOrientationsを調整した。

**graphAreaViewのAutoLayoutの修正**
![スクリーンショット 2023-06-24 10 53 49](https://github.com/MasayukiKawashima/diet-app/assets/82994988/5895f912-2d6f-4f2e-9367-c38f403779af)
Bottomの余白を10pt追加した

## 今後のタスク

- 画面回転に関する廃止またはサポートされていないコードの調整
shouldAutorotate→廃止されている。機能していない。
UIDevice.orientation→iOS16以降ではサポートされていないのでUIWindowScene.requestGeometryUpdate(_:)に置き換え

- Mac の買い替え
現在のXcodeとSwiftのverが古く上記の作業が行えないが、現在の使用しているMacが古くXCodeがアップデートできないため買い替えを行う。アプリ申請も現在のXCodeのverでは行えない。
[iOSアプリのApp Storeへの提出](https://developer.apple.com/jp/ios/submit/)

## 振り返り

- 調査に時間がかかってしまった。
現在のMacが古いせいであまり情報がない挙動や警告がでていた。それを解決する情報も最新verのXcode等を前提としているものが多く、自身の環境に当てはまらないものばかりだった。