### PR TITLE
GraphPageのPaging実装と関係メソッドのDRY

### DIFF
--- a/DietApp.xcodeproj/project.pbxproj
+++ b/DietApp.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		FA41A2F02A1C861E008DC83E /* TabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA41A2EF2A1C861E008DC83E /* TabBarController.swift */; };
 		FA41A2F22A1C8734008DC83E /* GraphViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA41A2F12A1C8734008DC83E /* GraphViewController.swift */; };
 		FA41A2F42A1C877E008DC83E /* SettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA41A2F32A1C877E008DC83E /* SettingsViewController.swift */; };
+		FA658AD32A4957B200669852 /* PagingModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA658AD22A4957B200669852 /* PagingModel.swift */; };
 		FA68AF212A135F6F00B69D4A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA68AF202A135F6F00B69D4A /* AppDelegate.swift */; };
 		FA68AF232A135F6F00B69D4A /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA68AF222A135F6F00B69D4A /* SceneDelegate.swift */; };
 		FA68AF282A135F6F00B69D4A /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = FA68AF262A135F6F00B69D4A /* Main.storyboard */; };
@@ -95,6 +96,7 @@
 		FA41A2EF2A1C861E008DC83E /* TabBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarController.swift; sourceTree = "<group>"; };
 		FA41A2F12A1C8734008DC83E /* GraphViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphViewController.swift; sourceTree = "<group>"; };
 		FA41A2F32A1C877E008DC83E /* SettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewController.swift; sourceTree = "<group>"; };
+		FA658AD22A4957B200669852 /* PagingModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PagingModel.swift; sourceTree = "<group>"; };
 		FA68AF1D2A135F6F00B69D4A /* DietApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = DietApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		FA68AF202A135F6F00B69D4A /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		FA68AF222A135F6F00B69D4A /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -192,6 +194,7 @@
 		FA41A2F52A1C8834008DC83E /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				FA658AD22A4957B200669852 /* PagingModel.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -593,6 +596,7 @@
 				FA41A2EE2A1C8531008DC83E /* TopPageViewController.swift in Sources */,
 				FAFF6F592A21ACE40092A1A3 /* WeightTableViewCell.swift in Sources */,
 				FA41A2F42A1C877E008DC83E /* SettingsViewController.swift in Sources */,
+				FA658AD32A4957B200669852 /* PagingModel.swift in Sources */,
 				FA3142722A418E9B00254D60 /* NavigationController+Orientation.swift in Sources */,
 				FA68AF212A135F6F00B69D4A /* AppDelegate.swift in Sources */,
 				FA0F9ED12A3016D100C7E888 /* UITabBarController+Orientation.swift in Sources */,

--- a/DietApp/GraphPage/GraphPageViewController.swift
+++ b/DietApp/GraphPage/GraphPageViewController.swift
@@ -8,7 +8,8 @@
 import UIKit
 
 class GraphPageViewController: UIPageViewController {
-  private var controllers: [UIViewController] = [GraphViewController()]
+  var controllers: [UIViewController] = [GraphViewController()]
+  let pagingModel = PagingModel()
   
   override var shouldAutorotate: Bool {
     if let VC = controllers.first {
@@ -61,16 +62,18 @@ extension GraphPageViewController: UIPageViewControllerDataSource {
   func presentationCount(for pageViewController: UIPageViewController) -> Int {
     return self.controllers.count
   }
-  //スワイプ時処理は保留
+
+  //右スワイプ（左から右にスワイプ）戻る
   func pageViewController(_ pageViewController: UIPageViewController, viewControllerBefore viewController: UIViewController) -> UIViewController? {
-    nil
+    pagingModel.instantiate(Identifier: .graphVC, direction: .previous)
   }
   
+  //左スワイプ（右から左にスワイプ）進む
   func pageViewController(_ pageViewController: UIPageViewController, viewControllerAfter viewController: UIViewController) -> UIViewController? {
-    nil
+    pagingModel.instantiate(Identifier: .graphVC, direction: .next)
   }
 }
-
+//NavigationBarの設定
 extension GraphPageViewController {
   //titleの設定
   func navigationBarTitleSetting (){
@@ -121,10 +124,22 @@ extension GraphPageViewController {
   }
   //barButtonの設定
   func navigationBarButtonSetting() {
-    let nextBarButtonItem = UIBarButtonItem(image: UIImage(systemName: "arrow.right"), style: .done, target: self, action: nil)
-    let previousBarButtomItem = UIBarButtonItem(image: UIImage(systemName: "arrow.left"), style: .done, target: self, action: nil)
+    let nextBarButtonItem = UIBarButtonItem(image: UIImage(systemName: "arrow.right"), style: .done, target: self, action: #selector(buttonPaging(_:)))
+    nextBarButtonItem.tag = 1
+    let previousBarButtomItem = UIBarButtonItem(image: UIImage(systemName: "arrow.left"), style: .done, target: self, action: #selector(buttonPaging(_:)))
+    previousBarButtomItem.tag = 2
     
     self.navigationItem.rightBarButtonItem = nextBarButtonItem
     self.navigationItem.leftBarButtonItem = previousBarButtomItem
+  }
+  
+  @objc func buttonPaging(_ sender: UIBarButtonItem) {
+    let VC = storyboard?.instantiateViewController(withIdentifier: "GraphVC") as! GraphViewController
+    if sender.tag == 1 {
+      setViewControllers([VC], direction: .forward, animated: true)
+    }
+    if sender.tag == 2 {
+      setViewControllers([VC], direction: .reverse, animated: true)
+    }
   }
 }

--- a/DietApp/GraphPage/GraphViewController.swift
+++ b/DietApp/GraphPage/GraphViewController.swift
@@ -161,6 +161,10 @@ extension GraphViewController {
     dataSet.setColor(graphLineColor)
     //エントリーポイントのラベルを非表示
     dataSet.drawValuesEnabled = false
+    //エントリーポイントタップ時の十字のハイライトを非表示
+    dataSet.highlightEnabled = false
+    
+    
     //データのセット
     let data = LineChartData(dataSet: dataSet)
     graphView.graphAreaView.data = data
@@ -201,5 +205,7 @@ extension GraphViewController {
     //Y軸の軸線と最初のエントリーポイントの間の余白を設定
     graphView.graphAreaView.xAxis.spaceMin = 0.5
     graphView.graphAreaView.xAxis.spaceMax = 0.5
+    //グラフ内をダブルタップ及びピンチジェスチャーしたときのズームを出来ないようにする
+    graphView.graphAreaView.doubleTapToZoomEnabled = false
   }
 }

--- a/DietApp/Model/PagingModel.swift
+++ b/DietApp/Model/PagingModel.swift
@@ -1,0 +1,45 @@
+//
+//  PagingModel.swift
+//  DietApp
+//
+//  Created by 川島真之 on 2023/06/26.
+//
+
+import Foundation
+import UIKit
+
+class PagingModel {
+  enum Direction {
+    case next
+    case previous
+  }
+  
+  enum identifier {
+    case topVC
+    case graphVC
+  }
+  //6.26　一応遷移方向によって分岐させている
+  func instantiate(Identifier: identifier,direction: Direction) -> UIViewController {
+    let stroyBoard = UIStoryboard(name: "Main", bundle: nil)
+    
+    switch Identifier {
+    case .topVC:
+      let viewController = stroyBoard.instantiateViewController(withIdentifier: "TopVC") as! TopViewController
+      switch direction {
+      case .next:
+        return viewController
+      case .previous:
+        return viewController
+      }
+      
+    case .graphVC:
+      let viewController = stroyBoard.instantiateViewController(withIdentifier: "GraphVC") as! GraphViewController
+      switch direction {
+      case .next:
+        return viewController
+      case .previous:
+        return viewController
+      }
+    }
+  }
+}

--- a/DietApp/TopPage/TopPageViewController.swift
+++ b/DietApp/TopPage/TopPageViewController.swift
@@ -8,8 +8,9 @@
 import UIKit
 
 class TopPageViewController: UIPageViewController {
-  //現在のページのみを保持する配列
-  var controllers: [TopViewController] = []
+ 
+  var controllers: [UIViewController] = []
+  var pasingModel = PagingModel()
   
   override var shouldAutorotate: Bool {
     if let vc = controllers.first {
@@ -49,36 +50,18 @@ class TopPageViewController: UIPageViewController {
 
 //PageViewContollerの内容の設定
 extension TopPageViewController: UIPageViewControllerDataSource {
-  //スワイプ処理に関する列挙体
-  enum Direction {
-    case previous
-    case next
-  }
-  //スワイプ時に遷移先のViewControllerのインスタンスを生成する関数
-  //pageIndexのインクリメント、デクリメントは関数内では行わない
-  func  instantiate(direction: Direction) -> TopViewController? {
-    let VC = storyboard?.instantiateViewController(withIdentifier: "TopVC") as! TopViewController
-    //６．２５　現状条件分岐させてる意味がないがとりあえずこのままにしておく
-    switch direction {
-    case .previous:
-      self.controllers[0] = VC
-      return VC
-    case .next :
-      self.controllers[0] = VC
-      return VC
-    }
-  }
-  
+
   func presentationCount(for pageViewController: UIPageViewController) -> Int {
     return self.controllers.count
   }
   //各スワイプ時の処理
+  //右スワイプ（左から右にスワイプ）戻る
   func pageViewController(_ pageViewController: UIPageViewController, viewControllerBefore viewController: UIViewController) -> UIViewController? {
-    return instantiate(direction: .next)
+    return pasingModel.instantiate(Identifier: .topVC, direction: .previous)
   }
-  
+  //左スワイプ（右から左にスワイプ）進む
   func pageViewController(_ pageViewController: UIPageViewController, viewControllerAfter viewController: UIViewController) -> UIViewController? {
-    return instantiate(direction: .previous)
+    return pasingModel.instantiate(Identifier: .topVC, direction: .next)
   }
 }
 //navigationBarの設定
@@ -157,16 +140,12 @@ extension TopPageViewController {
   }
   
   @objc func buttonPaging(_ sender: UIBarButtonItem) {
+    let VC = storyboard?.instantiateViewController(withIdentifier: "TopVC") as! TopViewController
     if sender.tag == 1 {
-      if let nextVC = instantiate(direction: .next){
-        setViewControllers([nextVC], direction: .forward, animated: true)
-      }
+      setViewControllers([VC], direction: .forward, animated: true)
     }
     if sender.tag == 2 {
-      if let previousVC = instantiate(direction: .previous){
-        setViewControllers([previousVC], direction: .reverse, animated: true)
-      }
+      setViewControllers([VC], direction: .reverse, animated: true)
     }
   }
 }
-


### PR DESCRIPTION
## issue
close #29 
## やったこと

- GraphPageのPaging実装
- Paging時の遷移先ViewControllerの取得と遷移方向による条件分岐のメソッドをDRYにした。

- GraphPageのグラフ内のUI調整
グラフ内のエントリーポイントをタップした時のハイライト表示を非表示にした。
グラフ内をダブルタップ及びピンチジェスチャーしたときのズームを出来ないようにした。
※paging機能の確認作業を行いやすくするために、不必要な機能を無くした。

## 振り返り

- メソッドをDRYについてうまく出来たか自信がない。
それぞれの要素について再利用できるものにすべきかどうか、どこまで抽象化すべきかなどまだ感覚が掴めてない。
