### PR TITLE
ログの確認終了

### DIFF
--- a/DietApp/View/TopPage/Cell/MemoTableViewCell.swift
+++ b/DietApp/View/TopPage/Cell/MemoTableViewCell.swift
@@ -16,6 +16,7 @@ class MemoTableViewCell: UITableViewCell {
         // Initialization code
     
     memoTextField.delegate = self
+    memoTextField.autocorrectionType = .no
     
     
     let placeholderText = "ひとことメモ"

--- a/DietApp/View/TopPage/Cell/WeightTableViewCell.swift
+++ b/DietApp/View/TopPage/Cell/WeightTableViewCell.swift
@@ -19,6 +19,8 @@ class WeightTableViewCell: UITableViewCell {
     //キーボードタイプ設定
     weightTextField.keyboardType = .decimalPad
     
+    weightTextField.autocorrectionType = .no
+    
     let placeholderText = "体重を入力"
     let attributes = [
       NSAttributedString.Key.font: UIFont.systemFont(ofSize: 14)


### PR DESCRIPTION
## issue
close #31 
## やったこと
ログの確認。
警告の修正はしなかった。
## しなかった理由
下記のふたつの警告が発生していたが、appleのバグによるものらしく放置しても問題ないらしい。これらの警告を消す方法をいくつか試したが効果がなかったのでひとまず放置することにした。

- TopPageの体重セルのtextFieldをタップした時の警告
2023-06-27 09:53:53.070198+0900 DietApp[7359:383934] Can't find keyplane that supports type 8 for keyboard iPhone-PortraitTruffle-DecimalPad; using 27112_PortraitTruffle_iPhone-Simple-Pad_Default

- 体重セルをタップした後にメモセルをタップしたときの警告
2023-06-27 09:54:46.297360+0900 DietApp[7359:383934] [LayoutConstraints] Unable to simultaneously satisfy constraints.
	Probably at least one of the constraints in the following list is one you don't want. 
	Try this: 
		(1) look at each constraint and try to figure out which you don't expect; 
		(2) find the code that added the unwanted constraint or constraints and fix it. 
(
    "<NSLayoutConstraint:0x600001544050 'accessoryView.bottom' _UIRemoteKeyboardPlaceholderView:0x7fdb34f44530.bottom == _UIKBCompatInputView:0x7fdb36937e30.top   (active)>",
    "<NSLayoutConstraint:0x600001535c70 'assistantHeight' TUISystemInputAssistantView:0x7fdb36933520.height == 45   (active)>",
    "<NSLayoutConstraint:0x6000015340a0 'assistantView.bottom' TUISystemInputAssistantView:0x7fdb36933520.bottom == _UIKBCompatInputView:0x7fdb36937e30.top   (active)>",
    "<NSLayoutConstraint:0x600001547610 'assistantView.top' V:[_UIRemoteKeyboardPlaceholderView:0x7fdb34f44530]-(0)-[TUISystemInputAssistantView:0x7fdb36933520]   (active)>"
)

Will attempt to recover by breaking constraint 
<NSLayoutConstraint:0x600001547610 'assistantView.top' V:[_UIRemoteKeyboardPlaceholderView:0x7fdb34f44530]-(0)-[TUISystemInputAssistantView:0x7fdb36933520]   (active)>

Make a symbolic breakpoint at UIViewAlertForUnsatisfiableConstraints to catch this in the debugger.
The methods in the UIConstraintBasedLayoutDebugging category on UIView listed in <UIKitCore/UIView.h> may also be helpful.