### PR TITLE
TopPageの写真挿入機能の実装 #33

### DIFF
--- a/DietApp.xcodeproj/project.pbxproj
+++ b/DietApp.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		FA41A2F22A1C8734008DC83E /* GraphViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA41A2F12A1C8734008DC83E /* GraphViewController.swift */; };
 		FA41A2F42A1C877E008DC83E /* SettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA41A2F32A1C877E008DC83E /* SettingsViewController.swift */; };
 		FA658AD32A4957B200669852 /* PagingModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA658AD22A4957B200669852 /* PagingModel.swift */; };
+		FA658AD52A4C5FFA00669852 /* PhotoInteractionModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA658AD42A4C5FFA00669852 /* PhotoInteractionModel.swift */; };
 		FA68AF212A135F6F00B69D4A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA68AF202A135F6F00B69D4A /* AppDelegate.swift */; };
 		FA68AF232A135F6F00B69D4A /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA68AF222A135F6F00B69D4A /* SceneDelegate.swift */; };
 		FA68AF282A135F6F00B69D4A /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = FA68AF262A135F6F00B69D4A /* Main.storyboard */; };
@@ -97,6 +98,7 @@
 		FA41A2F12A1C8734008DC83E /* GraphViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphViewController.swift; sourceTree = "<group>"; };
 		FA41A2F32A1C877E008DC83E /* SettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewController.swift; sourceTree = "<group>"; };
 		FA658AD22A4957B200669852 /* PagingModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PagingModel.swift; sourceTree = "<group>"; };
+		FA658AD42A4C5FFA00669852 /* PhotoInteractionModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoInteractionModel.swift; sourceTree = "<group>"; };
 		FA68AF1D2A135F6F00B69D4A /* DietApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = DietApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		FA68AF202A135F6F00B69D4A /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		FA68AF222A135F6F00B69D4A /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -195,6 +197,7 @@
 			isa = PBXGroup;
 			children = (
 				FA658AD22A4957B200669852 /* PagingModel.swift */,
+				FA658AD42A4C5FFA00669852 /* PhotoInteractionModel.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -600,6 +603,7 @@
 				FA3142722A418E9B00254D60 /* NavigationController+Orientation.swift in Sources */,
 				FA68AF212A135F6F00B69D4A /* AppDelegate.swift in Sources */,
 				FA0F9ED12A3016D100C7E888 /* UITabBarController+Orientation.swift in Sources */,
+				FA658AD52A4C5FFA00669852 /* PhotoInteractionModel.swift in Sources */,
 				FABF36082A283CD0007D91DB /* GraphView.swift in Sources */,
 				FAFF6F602A21C60F0092A1A3 /* MemoTableViewCell.swift in Sources */,
 				FA32F4B82A32BD130058FD32 /* SettingsView.swift in Sources */,

--- a/DietApp/Info.plist
+++ b/DietApp/Info.plist
@@ -2,6 +2,12 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>ja_JP</string>
+	<key>CFBundleLocalizations</key>
+	<array>
+		<string>ja</string>
+	</array>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/DietApp/Model/PhotoInteractionModel.swift
+++ b/DietApp/Model/PhotoInteractionModel.swift
@@ -1,0 +1,44 @@
+//
+//  PhotoInteractionModel.swift
+//  DietApp
+//
+//  Created by 川島真之 on 2023/06/28.
+//
+
+import UIKit
+
+class PhotoInteractionModel {
+  //アクションシートの表示
+   func showPhotoSelectionActionSheet(from viewController: UIViewController) {
+    let actionSheet = UIAlertController(title: "写真の選択", message: nil, preferredStyle: .actionSheet)
+    
+    let cameraAction = UIAlertAction(title: "カメラ", style: .default) { action in
+      self.showImagePicker(sourceType: .camera, from: viewController)
+    }
+    
+    let photoLibraryAction = UIAlertAction(title: "フォトライブラリ", style: .default) { action in
+      self.showImagePicker(sourceType: .photoLibrary, from: viewController)
+    }
+    
+    let cancelAction = UIAlertAction(title: "キャンセル", style: .cancel)
+    
+    actionSheet.addAction(cameraAction)
+    actionSheet.addAction(photoLibraryAction)
+    actionSheet.addAction(cancelAction)
+    
+    viewController.present(actionSheet, animated: true, completion: nil)
+  }
+  //ImagePickerControllerの表示
+  func showImagePicker(sourceType: UIImagePickerController.SourceType, from viewController: UIViewController) {
+    if UIImagePickerController.isSourceTypeAvailable(sourceType) {
+      let imagePicker = UIImagePickerController()
+      imagePicker.sourceType = sourceType
+      if let delegate = viewController as? UIImagePickerControllerDelegate & UINavigationControllerDelegate {
+        imagePicker.delegate = delegate
+      }else{
+        print("UIImagePickerControllerDelegateとUINavigationControllerDelegateのうち少なくとも一つが準拠されていないVCが引数として渡されました")
+      }
+      viewController.present(imagePicker, animated: true, completion: nil)
+    }
+  }
+}

--- a/DietApp/TopPage/TopViewController.swift
+++ b/DietApp/TopPage/TopViewController.swift
@@ -17,7 +17,6 @@ class TopViewController: UIViewController {
   }
   
   override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
-    
     return .portrait
   }
   
@@ -119,6 +118,8 @@ extension TopViewController: UITableViewDelegate,UITableViewDataSource {
     case .photoTableViewCell:
       let cell = tableView.dequeueReusableCell(withIdentifier: "PhotoTableViewCell", for: indexPath) as! PhotoTableViewCell
       cell.selectionStyle = UITableViewCell.SelectionStyle.none
+      //写真セルのデリゲート
+      cell.delegate = self
       return cell
     
     case .adTableViewCell:
@@ -172,4 +173,31 @@ extension TopViewController {
     view.endEditing(true)
   }
 }
+//写真セル内のボタン押下時処理
+extension TopViewController: PhotoTableViewCellDelegate, UIImagePickerControllerDelegate, UINavigationControllerDelegate {
+  //写真挿入ボタンとやり直しボタンを押した時の処理
+  func insertButonAction() {
+    let photoInteractionModel = PhotoInteractionModel()
+    photoInteractionModel.showPhotoSelectionActionSheet(from: self)
+  }
+  //カメラ及びフォトライブラリでキャンセルしたときのデリゲートメソッド
+  func imagePickerControllerDidCancel(_ picker: UIImagePickerController) {
+    picker.dismiss(animated: true, completion: nil)
+  }
+  //UIImagePickerController内で画像を選択したときの処理
+  func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
+    if let pickedImage = info[.originalImage] as? UIImage {
+      //現在表示されているPhotoTAbleViewCellのインスタンス取得
+      let photoTableViewCell = topView.tableView.visibleCells[2] as! PhotoTableViewCell
+      //ボタンとコメントラベルを非表示にする
+      photoTableViewCell.insertButton.isHidden = true
+      photoTableViewCell.commentLabel.isHidden = true
+      //取得したインスタンスのimageに選択した写真を格納
+      photoTableViewCell.photoImageView.image = pickedImage
+    }
+    //UIImagePickerControllerを閉じる
+    picker.dismiss(animated: true, completion: nil)
+  }
+}
+
 

--- a/DietApp/View/TopPage/Cell/PhotoTableViewCell.swift
+++ b/DietApp/View/TopPage/Cell/PhotoTableViewCell.swift
@@ -7,16 +7,36 @@
 
 import UIKit
 
+protocol PhotoTableViewCellDelegate {
+  func insertButonAction()
+}
+
 class PhotoTableViewCell: UITableViewCell {
 
   @IBOutlet weak var photoImageView: UIImageView!
+  @IBOutlet weak var insertButton: UIButton!
   
+  @IBOutlet weak var commentLabel: UILabel!
   @IBOutlet weak var redoButton: UIButton!
   
+  var delegate: PhotoTableViewCellDelegate?
+  
   override func awakeFromNib() {
-        super.awakeFromNib()
-        // Initialization code
+    super.awakeFromNib()
+    // Initialization code
+    //systemImageのサイズ調整
+    let symbolConfiguration = UIImage.SymbolConfiguration(pointSize: 40)
+    let image = insertButton.image(for: .normal)?.withConfiguration(symbolConfiguration)
+    insertButton.setImage(image, for: .normal)
+    insertButton.imageView?.contentMode = .scaleAspectFit
+    //ボタンのサイズ調整
+    if let image = image {
+      let buttonSize = CGSize(width: image.size.width + 20, height: image.size.height + 20)
+      insertButton.frame = CGRect(origin: insertButton.frame.origin, size: buttonSize)
+    }else{
+      return
     }
+  }
 
     override func setSelected(_ selected: Bool, animated: Bool) {
         super.setSelected(selected, animated: animated)
@@ -24,4 +44,11 @@ class PhotoTableViewCell: UITableViewCell {
         // Configure the view for the selected state
     }
     
+  @IBAction func insertButtonAction(_ sender: Any) {
+    delegate?.insertButonAction()
+  }
+  
+  @IBAction func redoButtonAction(_ sender: Any) {
+    delegate?.insertButonAction()
+  }
 }

--- a/DietApp/View/TopPage/Cell/PhotoTableViewCell.xib
+++ b/DietApp/View/TopPage/Cell/PhotoTableViewCell.xib
@@ -29,6 +29,9 @@
                         </constraints>
                         <state key="normal" title="Button"/>
                         <buttonConfiguration key="configuration" style="plain" image="gobackward" catalog="system"/>
+                        <connections>
+                            <action selector="redoButtonAction:" destination="KGk-i7-Jjw" eventType="touchUpInside" id="DYG-m8-sI3"/>
+                        </connections>
                     </button>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="タップして写真を挿入" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DL6-uU-7i8">
                         <rect key="frame" x="93.5" y="215" width="133" height="16"/>
@@ -36,28 +39,33 @@
                         <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <nil key="highlightedColor"/>
                     </label>
-                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="oKB-hh-oFN">
+                    <button opaque="NO" contentMode="scaleAspectFit" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="oKB-hh-oFN">
                         <rect key="frame" x="147" y="190" width="26.5" height="20"/>
                         <fontDescription key="fontDescription" type="system" pointSize="15"/>
                         <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
                         <state key="normal" image="camera" catalog="system"/>
+                        <connections>
+                            <action selector="insertButtonAction:" destination="KGk-i7-Jjw" eventType="touchUpInside" id="3op-f5-0EV"/>
+                        </connections>
                     </button>
                 </subviews>
                 <constraints>
                     <constraint firstAttribute="bottom" secondItem="Ytx-di-uC3" secondAttribute="bottom" constant="10" id="5Px-AN-Gut"/>
-                    <constraint firstItem="oKB-hh-oFN" firstAttribute="centerX" secondItem="H2p-sc-9uM" secondAttribute="centerX" id="KPi-J9-Cky"/>
+                    <constraint firstItem="DL6-uU-7i8" firstAttribute="centerX" secondItem="H2p-sc-9uM" secondAttribute="centerX" id="Ir6-0J-1cD"/>
+                    <constraint firstItem="oKB-hh-oFN" firstAttribute="centerX" secondItem="H2p-sc-9uM" secondAttribute="centerX" id="Iyb-zC-eO7"/>
                     <constraint firstAttribute="bottom" secondItem="rrK-eD-DU2" secondAttribute="bottom" constant="1.5" id="Kft-iq-6A3"/>
                     <constraint firstAttribute="trailing" secondItem="rrK-eD-DU2" secondAttribute="trailing" id="Qs1-TQ-HVp"/>
-                    <constraint firstItem="oKB-hh-oFN" firstAttribute="centerY" secondItem="H2p-sc-9uM" secondAttribute="centerY" id="U4y-xD-LZg"/>
-                    <constraint firstItem="DL6-uU-7i8" firstAttribute="centerX" secondItem="H2p-sc-9uM" secondAttribute="centerX" id="WGF-wB-5q7"/>
-                    <constraint firstItem="DL6-uU-7i8" firstAttribute="top" secondItem="oKB-hh-oFN" secondAttribute="bottom" constant="5" id="Zyl-fh-Y1T"/>
                     <constraint firstItem="rrK-eD-DU2" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="1.5" id="ffh-RN-yVf"/>
                     <constraint firstAttribute="trailing" secondItem="Ytx-di-uC3" secondAttribute="trailing" id="jN2-Oo-aBM"/>
                     <constraint firstItem="rrK-eD-DU2" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="rto-7n-huu"/>
+                    <constraint firstItem="DL6-uU-7i8" firstAttribute="top" secondItem="oKB-hh-oFN" secondAttribute="bottom" constant="5" id="se1-Iw-BEo"/>
+                    <constraint firstItem="oKB-hh-oFN" firstAttribute="centerY" secondItem="H2p-sc-9uM" secondAttribute="centerY" id="tXL-IB-RQi"/>
                 </constraints>
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
             <connections>
+                <outlet property="commentLabel" destination="DL6-uU-7i8" id="V1u-rp-Xsb"/>
+                <outlet property="insertButton" destination="oKB-hh-oFN" id="YXj-eT-eVf"/>
                 <outlet property="photoImageView" destination="rrK-eD-DU2" id="Utg-w1-725"/>
                 <outlet property="redoButton" destination="Ytx-di-uC3" id="GO2-68-B6c"/>
             </connections>


### PR DESCRIPTION
## issue
close #33

## やったこと

- TopPageの写真セル内のinsertButtonかredoButtonを押したときに、アクションシートが表示されるようにした。
- 上記の処理をモデルとしてまとめた。
- アクションシート内の選択肢をタップしたとき、UIImagePickerControllerを使いカメラ及びアルバムを使えるようにした。
- UIImagePickerControllerで選択した写真を写真セルのPhotoImageViewに表示するようにした。
- UIImagePickerController内のUIを日本語にした。
- 写真を表示するときにinsertButtonが非表示になるようにした。


## 今後のタスク

- DB周りの実装
- 写真周りのUIの調整

## 振り返り
アクションシートの処理をモデルとしてまとめたが、必要なかったかもしれない。
