### PR TITLE
TopPageのページング時の年、日付、曜日の更新処理を実装 

### DIFF
--- a/DietApp/GraphPage/GraphPageViewController.swift
+++ b/DietApp/GraphPage/GraphPageViewController.swift
@@ -65,12 +65,12 @@ extension GraphPageViewController: UIPageViewControllerDataSource {
 
   //右スワイプ（左から右にスワイプ）戻る
   func pageViewController(_ pageViewController: UIPageViewController, viewControllerBefore viewController: UIViewController) -> UIViewController? {
-    pagingModel.instantiate(Identifier: .graphVC, direction: .previous)
+    pagingModel.graphVCInstantiate(for: self, direction: .previous)
   }
   
   //左スワイプ（右から左にスワイプ）進む
   func pageViewController(_ pageViewController: UIPageViewController, viewControllerAfter viewController: UIViewController) -> UIViewController? {
-    pagingModel.instantiate(Identifier: .graphVC, direction: .next)
+    pagingModel.graphVCInstantiate(for: self, direction: .next)
   }
 }
 //NavigationBarの設定

--- a/DietApp/GraphPage/GraphViewController.swift
+++ b/DietApp/GraphPage/GraphViewController.swift
@@ -11,6 +11,11 @@ import Charts
 class GraphViewController: UIViewController {
   var graphView = GraphView()
   
+  //日付の管理のためのindex
+  var index: Int = 0
+  
+  var date = Date()
+  
   override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
     //左横画面に変更
     if(UIDevice.current.orientation.rawValue == 4){

--- a/DietApp/Model/PagingModel.swift
+++ b/DietApp/Model/PagingModel.swift
@@ -13,33 +13,47 @@ class PagingModel {
     case next
     case previous
   }
-  
-  enum identifier {
-    case topVC
-    case graphVC
-  }
-  //6.26　一応遷移方向によって分岐させている
-  func instantiate(Identifier: identifier,direction: Direction) -> UIViewController {
-    let stroyBoard = UIStoryboard(name: "Main", bundle: nil)
+//TopPageのページング先のインスタンス生成処理
+  func topVCInstantiate(for topPageViewController: TopPageViewController, direction: Direction)-> TopViewController {
+    //渡されてきたPageViewControllerから現在のViewControllerを取得
+    let currentTopVC = topPageViewController.viewControllers?.first as! TopViewController
+    //現在のViewControllerのindexを取得
+    let currentPageIndex = currentTopVC.index
     
-    switch Identifier {
-    case .topVC:
-      let viewController = stroyBoard.instantiateViewController(withIdentifier: "TopVC") as! TopViewController
-      switch direction {
-      case .next:
-        return viewController
-      case .previous:
-        return viewController
-      }
-      
-    case .graphVC:
-      let viewController = stroyBoard.instantiateViewController(withIdentifier: "GraphVC") as! GraphViewController
-      switch direction {
-      case .next:
-        return viewController
-      case .previous:
-        return viewController
-      }
+    let stroyBoard = UIStoryboard(name: "Main", bundle: nil)
+    let topVC = stroyBoard.instantiateViewController(withIdentifier: "TopVC") as! TopViewController
+    
+    
+    switch direction {
+    case .next:
+      let nextPageIndex = currentPageIndex + 1
+      topVC.index = nextPageIndex
+      return topVC
+    case .previous:
+      let nextPageIndex = currentPageIndex - 1
+      topVC.index = nextPageIndex
+      return topVC
+    }
+  }
+  //GraphPageのページング先のインスタンス生成処理
+  func graphVCInstantiate(for graphPageViewController: GraphPageViewController, direction: Direction)-> GraphViewController {
+    //渡されてきたPageViewControllerから現在のViewControllerを取得
+    let currentTopVC = graphPageViewController.controllers.first! as! GraphViewController
+    //現在のViewControllerのindexを取得
+    let currentPageIndex = currentTopVC.index
+    
+    let stroyBoard = UIStoryboard(name: "Main", bundle: nil)
+    let graphVC = stroyBoard.instantiateViewController(withIdentifier: "GraphVC") as! GraphViewController
+    
+    switch direction {
+    case .next:
+      let nextPageIndex = currentPageIndex + 1
+      graphVC.index = nextPageIndex
+      return graphVC
+    case .previous:
+      let previosPageIndex = currentPageIndex - 1
+      graphVC.index = previosPageIndex
+      return graphVC
     }
   }
 }

--- a/DietApp/TopPage/TopPageViewController.swift
+++ b/DietApp/TopPage/TopPageViewController.swift
@@ -9,7 +9,7 @@ import UIKit
 
 class TopPageViewController: UIPageViewController {
  
-  var controllers: [UIViewController] = []
+  var controllers: [TopViewController] = []
   var pasingModel = PagingModel()
   
   override var shouldAutorotate: Bool {
@@ -30,13 +30,16 @@ class TopPageViewController: UIPageViewController {
         super.viewDidLoad()
       
       self.dataSource = self
+      self.delegate = self
 
       self.initTopPageViewContoller()
         // Do any additional setup after loading the view.
+      if let currentVC = self.viewControllers?.first{
+        let currentVC = currentVC as! TopViewController
+        navigationBarTitleSetting(currentVC: currentVC)
+      }
       
-      navigationBarTitleSetting()
       navigationBarButtonSetting()
-
     }
   
   private func initTopPageViewContoller() {
@@ -57,38 +60,67 @@ extension TopPageViewController: UIPageViewControllerDataSource {
   //各スワイプ時の処理
   //右スワイプ（左から右にスワイプ）戻る
   func pageViewController(_ pageViewController: UIPageViewController, viewControllerBefore viewController: UIViewController) -> UIViewController? {
-    return pasingModel.instantiate(Identifier: .topVC, direction: .previous)
+    return pasingModel.topVCInstantiate(for: self, direction: .previous)
   }
   //左スワイプ（右から左にスワイプ）進む
   func pageViewController(_ pageViewController: UIPageViewController, viewControllerAfter viewController: UIViewController) -> UIViewController? {
-    return pasingModel.instantiate(Identifier: .topVC, direction: .next)
+    return pasingModel.topVCInstantiate(for: self, direction: .next)
+  }
+}
+//遷移時の処理
+extension TopPageViewController: UIPageViewControllerDelegate {
+  //遷移が終わった後に呼び出されるデリゲートメソッド
+  func pageViewController(_ pageViewController: UIPageViewController, didFinishAnimating finished: Bool, previousViewControllers: [UIViewController], transitionCompleted completed: Bool) {
+    //遷移が完了したら
+    if completed{
+      let currentVC = pageViewController.viewControllers?.first as! TopViewController
+      navigationBarTitleSetting(currentVC: currentVC)
+    }
   }
 }
 //navigationBarの設定
 extension TopPageViewController {
   //titileの設定
-  func navigationBarTitleSetting (){
-    let yearText = "2023"
-    let dateText = "5.24"
-    let dayOfWeekText = "wed"
+  func navigationBarTitleSetting (currentVC: TopViewController){
+    var yearText = ""
+    var dateText = ""
+    var dayOfWeekText = ""
     let dateFontSize: CGFloat = 18.0
     let fontSize: CGFloat = 14.0
+    
+    //現在のページの年、日付、曜日のデータを取得
+    let date = Date()
+    let modifiedDate = Calendar.current.date(byAdding: .day, value: currentVC.index, to: date)
 
     // カスタムビューをインスタンス化
     let customTitleView = UIView(frame: CGRect(x: 0, y: 0, width: 200, height: 44))
+    
+    //年の表示形式の設定
+    let yearFormatter = DateFormatter()
+    yearFormatter.dateFormat = "yyyy"
+    yearText = yearFormatter.string(from: modifiedDate!)
 
-    // UILabelを作成してテキストを設定
     let yearTextLabel = UILabel(frame: CGRect(x: 0, y: 0, width: 100, height: 22))
     yearTextLabel.text = yearText
     yearTextLabel.font = UIFont(name: "Thonburi", size: fontSize)
     yearTextLabel.textColor = .black
     yearTextLabel.sizeToFit()
-
+    
+    //日付の表示形式を設定
+    let dateFormatter = DateFormatter()
+    dateFormatter.dateFormat = "M.d"
+    dateText = dateFormatter.string(from: modifiedDate!)
+    
     let dateTextLabel = UILabel(frame: CGRect(x: 0, y: 0, width: 100, height: 22))
     dateTextLabel.text = dateText
     dateTextLabel.font = UIFont(name: "Thonburi-Bold", size: dateFontSize)
     dateTextLabel.textColor = .black
     dateTextLabel.sizeToFit()
+    
+    //曜日の表示形式の設定
+    let dayOfWeek = Calendar.current.component(.weekday, from: modifiedDate!)
+    let weekDays = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"]
+    dayOfWeekText = weekDays[dayOfWeek - 1]
 
     let dayOfWeekTextLabel = UILabel(frame: CGRect(x: 0, y: 0, width: 100, height: 22))
     dayOfWeekTextLabel.text = dayOfWeekText
@@ -128,7 +160,6 @@ extension TopPageViewController {
   }
   
   //BarButtonの設定
-  //6.20ボタン押下時の処理は保留
   func navigationBarButtonSetting() {
     let nextBarButtonItem = UIBarButtonItem(image: UIImage(systemName: "arrow.right"), style: .done, target: self, action: #selector(buttonPaging(_:)))
     nextBarButtonItem.tag = 1
@@ -138,14 +169,24 @@ extension TopPageViewController {
     self.navigationItem.rightBarButtonItem = nextBarButtonItem
     self.navigationItem.leftBarButtonItem = previousBarButtomItem
   }
-  
+  //BarButton押下時の画面遷移
   @objc func buttonPaging(_ sender: UIBarButtonItem) {
-    let VC = storyboard?.instantiateViewController(withIdentifier: "TopVC") as! TopViewController
+    let currentVC = self.viewControllers?.first as! TopViewController
+    let currentIndex = currentVC.index
+    let topVC = storyboard?.instantiateViewController(withIdentifier: "TopVC") as! TopViewController
+    //next
     if sender.tag == 1 {
-      setViewControllers([VC], direction: .forward, animated: true)
+      let nextIndex = currentIndex + 1
+      topVC.index = nextIndex
+      navigationBarTitleSetting(currentVC: topVC)
+      setViewControllers([topVC], direction: .forward, animated: true)
     }
+    //previous
     if sender.tag == 2 {
-      setViewControllers([VC], direction: .reverse, animated: true)
+      let nextIndex = currentIndex - 1
+      topVC.index = nextIndex
+      navigationBarTitleSetting(currentVC: topVC)
+      setViewControllers([topVC], direction: .reverse, animated: true)
     }
   }
 }

--- a/DietApp/TopPage/TopViewController.swift
+++ b/DietApp/TopPage/TopViewController.swift
@@ -10,6 +10,10 @@ import RealmSwift
 
 class TopViewController: UIViewController {
   var topView = TopView()
+  //日付の管理のためのindex
+  var index: Int = 0
+  
+  var date = Date()
   //回転を許可するかどうかを決める
   //デバイスの向きが変更されたときに呼び出される
   override var shouldAutorotate: Bool {
@@ -71,6 +75,10 @@ class TopViewController: UIViewController {
     topView.tableView.rowHeight = UITableView.automaticDimension
     //セル間の区切り線を非表示
     topView.tableView.separatorStyle = .none
+    
+    print("ああああああああああああああああああああああああああ")
+    print(index)
+    print("あああああああああああああああああああああああああああ")
     
   }
 


### PR DESCRIPTION
## issue
close #37

## 概要
TopPageのスワイプ時とNavigationBar内のボタンによる画面遷移時にNavigationBarの年、日付、曜日のカスタムタイトルが更新されるようにした。

## やったこと
PasingModelのtopVCInstantiate()とTopPagingViewControllerのbuttonPaging()でindexのインクリメント、デクリメントを行いそれを次の 画面のViewControllerのindexに代入することでページ情報を管理できるようにした。そして画面遷移時にnavigationBarTitleSetting()を呼び出し、次の画面のindexをもとに年、日付、曜日の表示を更新するようにしている。

## 今後のタスク

- GraphPageで同様の処理を実装。
- TopPage、GraphPageのリファクタリング