### PR TITLE
GraphPageのページング時の年月日の更新処理を実装した。

### DIFF
--- a/DietApp/GraphPage/GraphPageViewController.swift
+++ b/DietApp/GraphPage/GraphPageViewController.swift
@@ -31,9 +31,18 @@ class GraphPageViewController: UIPageViewController {
   override func viewDidLoad() {
     super.viewDidLoad()
     
+    self.dataSource = self
+    self.delegate = self
+    
     // Do any additional setup after loading the view.
     initGraphPageViewContoller()
-    navigationBarTitleSetting()
+    indexSetting()
+    
+    if let currentVC = self.viewControllers?.first{
+      let currentVC = currentVC as! GraphViewController
+      navigationBarTitleSetting(currentVC: currentVC)
+    }
+    
     navigationBarButtonSetting()
   }
   
@@ -73,30 +82,92 @@ extension GraphPageViewController: UIPageViewControllerDataSource {
     pagingModel.graphVCInstantiate(for: self, direction: .next)
   }
 }
+
+extension GraphPageViewController: UIPageViewControllerDelegate {
+  func pageViewController(_ pageViewController: UIPageViewController, didFinishAnimating finished: Bool, previousViewControllers: [UIViewController], transitionCompleted completed: Bool) {
+    if completed {
+      let currentVC = pageViewController.viewControllers?.first as! GraphViewController
+      navigationBarTitleSetting(currentVC: currentVC)
+    }
+  }
+}
 //NavigationBarの設定
 extension GraphPageViewController {
   //titleの設定
-  func navigationBarTitleSetting (){
-    let yearText = "2023"
-    let dateText = "5.1 - 5.31"
+  func navigationBarTitleSetting (currentVC: GraphViewController){
+    var yearText = ""
+    var dateText = ""
     let dateFontSize: CGFloat = 18.0
     let fontSize: CGFloat = 14.0
+    
+    let date = Date()
+    var modifiedDate = Date()
+    let calendar = Calendar.current
     
     // カスタムビューをインスタンス化
     let customTitleView = UIView(frame: CGRect(x: 0, y: 0, width: 200, height: self.navigationController!.navigationBar.frame.size.height))
     
-    // UILabelを作成してテキストを設定
-    let yearTextLabel = UILabel(frame: CGRect(x: 0, y: 0, width: 100, height: 22))
-    yearTextLabel.text = yearText
-    yearTextLabel.font = UIFont(name: "Thonburi", size: fontSize)
-    yearTextLabel.textColor = .black
-    yearTextLabel.sizeToFit()
+    //日付の設定
+    //まず現在の日付が月の前半の場合
+    if currentVC.index % 2 == 0 {
+      var firstDayString = ""
+      var sixteenthDayString = ""
+      
+      let value = currentVC.index/2
+      modifiedDate = calendar.date(byAdding: .month, value: value, to: date)!
+      
+      //月の最初の日と１７日目をDate型で取得
+      let firstDay = calendar.date(from: calendar.dateComponents([.year, .month], from: modifiedDate))!
+      let sixteenthDay = calendar.date(bySetting: .day, value: 16, of: modifiedDate)!
+      //日付の表示形式の設定
+      let dateFormatter = DateFormatter()
+      dateFormatter.dateFormat = "M.d"
+      //上の二つのDate型の日付をStringに変換し格納
+      firstDayString = dateFormatter.string(from: firstDay)
+      sixteenthDayString = dateFormatter.string(from: sixteenthDay)
+      //二つのStringの日付を合体させ、dateTextに格納
+      dateText = firstDayString + " - " + sixteenthDayString
+    }else{
+      //現在の日付が月の後半だった場合
+      var seventeenthDayString = ""
+      var lastDayString = ""
+      
+      //月の更新を行う。
+      let value = (currentVC.index - 1)/2
+      modifiedDate = calendar.date(byAdding: .month, value: value, to: date)!
+      
+      let seventeenthDay = calendar.date(bySetting: .day, value: 17, of: modifiedDate)!
+      //月末の取得は来月の月初を取得し、そこから１日戻すことで取得
+      let add = DateComponents(month: 1, day: -1)
+      let NextMonthFirstDay = calendar.date(from: calendar.dateComponents([.year, .month], from: modifiedDate))!
+      
+      let lastDay = calendar.date(byAdding: add, to: NextMonthFirstDay)!
+      
+      let dateFormatter = DateFormatter()
+      dateFormatter.dateFormat = "M.d"
+      //上の二つのDate型の日付をStringに変換し格納
+      seventeenthDayString = dateFormatter.string(from: seventeenthDay)
+      lastDayString = dateFormatter.string(from: lastDay)
+      
+      dateText = seventeenthDayString + " - " + lastDayString
+    }
     
     let dateTextLabel = UILabel(frame: CGRect(x: 0, y: 0, width: 100, height: 22))
     dateTextLabel.text = dateText
     dateTextLabel.font = UIFont(name: "Thonburi-Bold", size: dateFontSize)
     dateTextLabel.textColor = .black
     dateTextLabel.sizeToFit()
+    
+    //年の表示形式の設定
+    let yearFormatter = DateFormatter()
+    yearFormatter.dateFormat = "yyyy"
+    yearText = yearFormatter.string(from: modifiedDate)
+   
+    let yearTextLabel = UILabel(frame: CGRect(x: 0, y: 0, width: 100, height: 22))
+    yearTextLabel.text = yearText
+    yearTextLabel.font = UIFont(name: "Thonburi", size: fontSize)
+    yearTextLabel.textColor = .black
+    yearTextLabel.sizeToFit()
     
     //AutoLayoutを使用するための設定
     yearTextLabel.translatesAutoresizingMaskIntoConstraints = false
@@ -134,12 +205,55 @@ extension GraphPageViewController {
   }
   
   @objc func buttonPaging(_ sender: UIBarButtonItem) {
-    let VC = storyboard?.instantiateViewController(withIdentifier: "GraphVC") as! GraphViewController
+    let currentVC = self.viewControllers?.first as! GraphViewController
+    let currentIndex = currentVC.index
+    let graphVC = storyboard?.instantiateViewController(withIdentifier: "GraphVC") as! GraphViewController
+    
     if sender.tag == 1 {
-      setViewControllers([VC], direction: .forward, animated: true)
+      let nextIndex = currentIndex + 1
+      graphVC.index = nextIndex
+      navigationBarTitleSetting(currentVC: graphVC)
+      setViewControllers([graphVC], direction: .forward, animated: true)
     }
     if sender.tag == 2 {
-      setViewControllers([VC], direction: .reverse, animated: true)
+      let nextIndex = currentIndex - 1
+      graphVC.index = nextIndex
+      navigationBarTitleSetting(currentVC: graphVC)
+      setViewControllers([graphVC], direction: .reverse, animated: true)
     }
   }
+  //月の上旬と下旬によるindexの調整を行うメソッド
+  //現在の日付が月の下旬ならindexに1をたす
+  func indexSetting() {
+    let currentDate = Date()
+    let calendar = Calendar.current
+    let components = calendar.dateComponents([.day, .month], from: currentDate)
+    if let day = components.day {
+      if day >= 17 {
+        let currentVC = self.viewControllers?.first as! GraphViewController
+        currentVC.index += 1
+      }
+    }
+  }
+  //7.4　下のメソッドは必要ないが今後の参考のためにコメントアウトしておく
+  //指定した月の最後の日付を取得するメソッド
+  //指定した月の次の月の１日を取得し、そこから１日引くことで最後の日付を取得している。
+//  func getLastDayOfMonth(month: Int, year: Int) -> Int {
+//    let calendar = Calendar.current
+//
+//    // 次の月の1日を表すDateオブジェクトを取得
+//    var components = DateComponents()
+//    components.year = year
+//    components.month = month + 1
+//    components.day = 1
+//    let nextMonthFirstDay = calendar.date(from: components)
+//
+//    // 指定した月の最後の日を取得するための計算
+//    //上で取得した次の月の１日から１日引いている
+//    if let lastDay = calendar.date(byAdding: .day, value: -1, to: nextMonthFirstDay!) {
+//      return calendar.component(.day, from: lastDay)
+//    } else {
+//      return 31 // Default to 31 (maximum number of days in a month)
+//    }
+//  }
 }

--- a/DietApp/GraphPage/GraphViewController.swift
+++ b/DietApp/GraphPage/GraphViewController.swift
@@ -57,6 +57,8 @@ class GraphViewController: UIViewController {
 //      navigationBarTitleSetting()
       
       graphSetting()
+      
+    
     }
   
   override func loadView() {

--- a/DietApp/Model/PagingModel.swift
+++ b/DietApp/Model/PagingModel.swift
@@ -38,9 +38,9 @@ class PagingModel {
   //GraphPageのページング先のインスタンス生成処理
   func graphVCInstantiate(for graphPageViewController: GraphPageViewController, direction: Direction)-> GraphViewController {
     //渡されてきたPageViewControllerから現在のViewControllerを取得
-    let currentTopVC = graphPageViewController.controllers.first! as! GraphViewController
+    let currentGraphVC = graphPageViewController.viewControllers?.first! as! GraphViewController
     //現在のViewControllerのindexを取得
-    let currentPageIndex = currentTopVC.index
+    let currentPageIndex = currentGraphVC.index
     
     let stroyBoard = UIStoryboard(name: "Main", bundle: nil)
     let graphVC = stroyBoard.instantiateViewController(withIdentifier: "GraphVC") as! GraphViewController
@@ -51,8 +51,8 @@ class PagingModel {
       graphVC.index = nextPageIndex
       return graphVC
     case .previous:
-      let previosPageIndex = currentPageIndex - 1
-      graphVC.index = previosPageIndex
+      let nextPageIndex = currentPageIndex - 1
+      graphVC.index = nextPageIndex
       return graphVC
     }
   }

--- a/DietApp/SceneDelegate.swift
+++ b/DietApp/SceneDelegate.swift
@@ -16,7 +16,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
     // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
     // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
-    guard let _ = (scene as? UIWindowScene) else { return }
+    //guard let _ = (scene as? UIWindowScene) else { return }
   }
 
   func sceneDidDisconnect(_ scene: UIScene) {

--- a/DietApp/TopPage/TopViewController.swift
+++ b/DietApp/TopPage/TopViewController.swift
@@ -75,11 +75,6 @@ class TopViewController: UIViewController {
     topView.tableView.rowHeight = UITableView.automaticDimension
     //セル間の区切り線を非表示
     topView.tableView.separatorStyle = .none
-    
-    print("ああああああああああああああああああああああああああ")
-    print(index)
-    print("あああああああああああああああああああああああああああ")
-    
   }
 
   override func loadView() {


### PR DESCRIPTION
## issue
close #41 
## やったこと
GraphPageにおいて、画面のスワイプ時およびNavigationBar内の左右のボタンを押して画面遷移した時にNavigationBar内の年月日を更新するようにした。
## 今後のタスク

- 当処理のリファクタリング

- 日付に紐づけられたDB周り処理

## 振り返り
日付の更新処理のロジックを考える際に ChatGPTでたたき台を作成したら、効率よく実装が行えた。