### PR TITLE
TopPageのMemoセルとPhotoセルに入力された値をRealmに保存し、永続化できるようにした。

### DIFF
--- a/DietApp/GraphPage/GraphPageViewController.swift
+++ b/DietApp/GraphPage/GraphPageViewController.swift
@@ -140,7 +140,7 @@ extension GraphPageViewController {
       //月末の取得は来月の月初を取得し、そこから１日戻すことで取得
       let add = DateComponents(month: 1, day: -1)
       let NextMonthFirstDay = calendar.date(from: calendar.dateComponents([.year, .month], from: modifiedDate))!
-      
+
       let lastDay = calendar.date(byAdding: add, to: NextMonthFirstDay)!
       
       let dateFormatter = DateFormatter()

--- a/DietApp/Info.plist
+++ b/DietApp/Info.plist
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSCameraUsageDescription</key>
+	<string>カメラを使用するには許可が必要です。</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>フォトライブラリを使用するには許可が必要です。</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>ja_JP</string>
 	<key>CFBundleLocalizations</key>


### PR DESCRIPTION
## issue
close #43 
## 概要
TopPageのMemoTableViewCellのMemoTextFieldに入力された値と、PhotoTableViewCellのinsertButton押下時のUIImagePickerControllerで取得した値をRealmやDocumentに保存できるようにした。
## やったこと

- メモの保存処理
MemoTableViewCellのMemoTextFieldに入力された文字をDateDataオブジェクトのmemoTextに保存できるようにした。

- 写真の保存処理
 UIImagePickerControllerで取得した写真にランダムな名前を付けてDocumentに保存し、DateDateオブジェクトのfileURLに写真の名前を保存できるようにした。
写真の読み込みは、DateDateオブジェクトのfileURLとDocumentのパスを合体させ、その合体後のパスをもとにUIImageの初期化で写真をロードする方法で行う。

## 今後のタスク

- 上記処理のリファクタリング
- ドキュメントから写真を読み込んだ時、写真の向きを調整する処理を実装する。
現段階でUIImagePickerControllerで取得した写真をドキュメントに保存し、その後読み込むと写真の向きが回転している場合がある。
- 値をRealmに保存する時に日付と紐づけて、読み込み時に検索できるようにする。
- Realmから値を読み込む時に、DateDateオブジェクトの存在の有無やオブジェクトのプロパティの中身について事前にチェックする処理を実装する。