### PR TITLE
写真が回転してしまう問題を修正 

### DIFF
--- a/DietApp/Model/RealmObject/DateData.swift
+++ b/DietApp/Model/RealmObject/DateData.swift
@@ -12,6 +12,6 @@ class DateData: Object {
   @objc dynamic var date: Date = Date()
   @objc dynamic var weight: String = ""
   @objc dynamic var memoText: String = ""
-  @objc dynamic var fileURL: String = ""
-  @objc dynamic var photoOrientation: String = ""
+  @objc dynamic var photoFileURL: String = ""
+  @objc dynamic var imageOrientationRawValue: Int = Int()
 }


### PR DESCRIPTION
## issue
close #47 

## やったこと
Documentsディレクトリに保存した写真を読み込んだ際に写真が回転してしまう問題を修正し、アプリ起動時や画面遷移時に写真が正しい向きで表示されるようにした。

## 問題の原因
写真をDocumentsディレクトリに保存する際に写真の回転情報が失われていたため、写真が反時計回りに９０°回転した状態で表示されていた。

## 修正方法
写真の取得時に、写真の回転情報を取り出しRelamに保存する。その後写真の読み込み時にRealmから回転情報を読み込み写真に付与する。

## 今後のタスク

- 写真のフォーマットの検討
現状PNGで保存しているが、JPEGを検討する。
