### PR TITLE
Realmに登録したObjectを日付を条件に検索できるようにした 

### DIFF
--- a/DietApp.xcodeproj/project.pbxproj
+++ b/DietApp.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		FA32F4C52A32BFCF0058FD32 /* NotificationTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = FA32F4C32A32BFCF0058FD32 /* NotificationTableViewCell.xib */; };
 		FA32F4C82A32C0900058FD32 /* ThemeColorTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA32F4C62A32C0900058FD32 /* ThemeColorTableViewCell.swift */; };
 		FA32F4C92A32C0900058FD32 /* ThemeColorTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = FA32F4C72A32C0900058FD32 /* ThemeColorTableViewCell.xib */; };
+		FA417BC02A5C428E00B53A0F /* DateDataRealmSearcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA417BBF2A5C428E00B53A0F /* DateDataRealmSearcher.swift */; };
 		FA41A2EC2A1C84CE008DC83E /* TopViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA41A2EB2A1C84CE008DC83E /* TopViewController.swift */; };
 		FA41A2EE2A1C8531008DC83E /* TopPageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA41A2ED2A1C8531008DC83E /* TopPageViewController.swift */; };
 		FA41A2F02A1C861E008DC83E /* TabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA41A2EF2A1C861E008DC83E /* TabBarController.swift */; };
@@ -95,6 +96,7 @@
 		FA32F4C32A32BFCF0058FD32 /* NotificationTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = NotificationTableViewCell.xib; sourceTree = "<group>"; };
 		FA32F4C62A32C0900058FD32 /* ThemeColorTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeColorTableViewCell.swift; sourceTree = "<group>"; };
 		FA32F4C72A32C0900058FD32 /* ThemeColorTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ThemeColorTableViewCell.xib; sourceTree = "<group>"; };
+		FA417BBF2A5C428E00B53A0F /* DateDataRealmSearcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateDataRealmSearcher.swift; sourceTree = "<group>"; };
 		FA41A2EB2A1C84CE008DC83E /* TopViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopViewController.swift; sourceTree = "<group>"; };
 		FA41A2ED2A1C8531008DC83E /* TopPageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopPageViewController.swift; sourceTree = "<group>"; };
 		FA41A2EF2A1C861E008DC83E /* TabBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarController.swift; sourceTree = "<group>"; };
@@ -186,6 +188,7 @@
 			isa = PBXGroup;
 			children = (
 				FA11122B2A5923F6007353EA /* IndexSettingModel.swift */,
+				FA417BBF2A5C428E00B53A0F /* DateDataRealmSearcher.swift */,
 			);
 			path = Logic;
 			sourceTree = "<group>";
@@ -641,6 +644,7 @@
 				FAFF6F532A2055430092A1A3 /* TopView.swift in Sources */,
 				FA11879E2A22D2A5004577F8 /* PhotoTableViewCell.swift in Sources */,
 				FA11122E2A592745007353EA /* Direction.swift in Sources */,
+				FA417BC02A5C428E00B53A0F /* DateDataRealmSearcher.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/DietApp/Model/Logic/DateDataRealmSearcher.swift
+++ b/DietApp/Model/Logic/DateDataRealmSearcher.swift
@@ -1,0 +1,21 @@
+//
+//  DateDataRealmSearcher.swift
+//  DietApp
+//
+//  Created by 川島真之 on 2023/07/10.
+//
+
+import Foundation
+import RealmSwift
+
+class DateDataRealmSearcher {
+  func searchForDateDataInRealm(currentDate: Date) -> Results<DateData> {
+    let realm = try! Realm()
+    //日付の正規化
+    let startOfDay = Calendar.current.startOfDay(for: currentDate)
+    let endOfDay = Calendar.current.date(byAdding: .day, value: 1, to: startOfDay)!
+    //検索
+    let results = realm.objects(DateData.self).filter("date >= %@ AND date < %@", startOfDay, endOfDay)
+    return results
+  }
+}


### PR DESCRIPTION
## 概要
RealmObjectを登録する時に、そのページの日付に編集されたdateプロパティを含めて登録することで、読み込み時にdateプロパティの値をもとに検索できるようにした。

## やったこと

- TopViewControllerのViewDidLoadでそのページのindexをもとに日付を編集してdateに代入するようにした。
dateにはそのページの日付と同じ日付の値が入るようにしてある。

- DateDataRealmSearcherというクラスを作り、その中にsearchForDateDataInRealmというRealmObjectを検索するメソッドを定義した。
日付を引数に取り、その日付を正規化し検索に利用する。

- TopPageの体重セルのweightTextFieldにユーザーが体重を入力した際に、その値をdate（上で編集済み）と共にRealmに登録するようにした。
その際にweightTextFieldに入力された値によってと、Realmに同日のObjectが既に存在するかどうかで条件分岐している。

- TopPageのTableViewの各セルの内容を決める際に、上で定義したメソッドを利用し現在のページの日付のRealmObjectが存在するかどうか検索できるようにした。
 TopPageのTableViewのtableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCellメソッド内でsearchForDateDataInRealmを呼び出し、存在すればそのObjectの中のプロパティの値を取り出しTextField等に格納する。
この機能はこのissueでは実装しない予定だったが、上の三つの機能を確認する上で同時に実装したほうが良いと思ったので実装した。

## 今後のタスク

- Modelクラス名の命名規則の揺れをなくす
クラス名の最後にModelをつけるかどうか
- Realmに日付と合わせて登録する処理を体重セル以外でも実装
その際に処理をモデルに移す。
