### PR TITLE
TopPageのMemo、PhotoセルのRealm登録の処理の修正をおこなった 

### DIFF
--- a/DietApp.xcodeproj/project.pbxproj
+++ b/DietApp.xcodeproj/project.pbxproj
@@ -12,7 +12,7 @@
 		60A4C6E95A42A5E6FBC4EC82 /* Pods_DietApp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 71B7CEEB90849C4649195C6F /* Pods_DietApp.framework */; };
 		FA0F9ECF2A2F0DEC00C7E888 /* GraphPageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA0F9ECE2A2F0DEC00C7E888 /* GraphPageViewController.swift */; };
 		FA0F9ED12A3016D100C7E888 /* UITabBarController+Orientation.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA0F9ED02A3016D100C7E888 /* UITabBarController+Orientation.swift */; };
-		FA11122C2A5923F6007353EA /* IndexSettingModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA11122B2A5923F6007353EA /* IndexSettingModel.swift */; };
+		FA11122C2A5923F6007353EA /* IndexSetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA11122B2A5923F6007353EA /* IndexSetting.swift */; };
 		FA11122E2A592745007353EA /* Direction.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA11122D2A592745007353EA /* Direction.swift */; };
 		FA11879E2A22D2A5004577F8 /* PhotoTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA11879C2A22D2A5004577F8 /* PhotoTableViewCell.swift */; };
 		FA11879F2A22D2A5004577F8 /* PhotoTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = FA11879D2A22D2A5004577F8 /* PhotoTableViewCell.xib */; };
@@ -81,7 +81,7 @@
 		F33E63A5ACE3D0B165D13D9B /* Pods-DietAppTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DietAppTests.debug.xcconfig"; path = "Target Support Files/Pods-DietAppTests/Pods-DietAppTests.debug.xcconfig"; sourceTree = "<group>"; };
 		FA0F9ECE2A2F0DEC00C7E888 /* GraphPageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphPageViewController.swift; sourceTree = "<group>"; };
 		FA0F9ED02A3016D100C7E888 /* UITabBarController+Orientation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITabBarController+Orientation.swift"; sourceTree = "<group>"; };
-		FA11122B2A5923F6007353EA /* IndexSettingModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IndexSettingModel.swift; sourceTree = "<group>"; };
+		FA11122B2A5923F6007353EA /* IndexSetting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IndexSetting.swift; sourceTree = "<group>"; };
 		FA11122D2A592745007353EA /* Direction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Direction.swift; sourceTree = "<group>"; };
 		FA11879C2A22D2A5004577F8 /* PhotoTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoTableViewCell.swift; sourceTree = "<group>"; };
 		FA11879D2A22D2A5004577F8 /* PhotoTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = PhotoTableViewCell.xib; sourceTree = "<group>"; };
@@ -187,7 +187,7 @@
 		FA1112302A59296B007353EA /* Logic */ = {
 			isa = PBXGroup;
 			children = (
-				FA11122B2A5923F6007353EA /* IndexSettingModel.swift */,
+				FA11122B2A5923F6007353EA /* IndexSetting.swift */,
 				FA417BBF2A5C428E00B53A0F /* DateDataRealmSearcher.swift */,
 			);
 			path = Logic;
@@ -627,7 +627,7 @@
 				FA3142702A41671900254D60 /* TopNavigationController.swift in Sources */,
 				FA3142742A4194F300254D60 /* GraphNavigationController.swift in Sources */,
 				FA41A2EE2A1C8531008DC83E /* TopPageViewController.swift in Sources */,
-				FA11122C2A5923F6007353EA /* IndexSettingModel.swift in Sources */,
+				FA11122C2A5923F6007353EA /* IndexSetting.swift in Sources */,
 				FAFF6F592A21ACE40092A1A3 /* WeightTableViewCell.swift in Sources */,
 				FA41A2F42A1C877E008DC83E /* SettingsViewController.swift in Sources */,
 				FA3142722A418E9B00254D60 /* NavigationController+Orientation.swift in Sources */,

--- a/DietApp/GraphPage/GraphPageViewController.swift
+++ b/DietApp/GraphPage/GraphPageViewController.swift
@@ -41,8 +41,8 @@ class GraphPageViewController: UIPageViewController {
       //NavigationBarTittleの設定
       navigationBarTitleSetting(currentVC: currentVC)
       //月の前半か後半かによるindexの調整
-      let indexSettingModel = IndexSettingModel()
-      let index = indexSettingModel.indexSetting()
+      let indexSetting = IndexSetting()
+      let index = indexSetting.indexSetting()
       currentVC.index = index
     }
     

--- a/DietApp/Model/Logic/IndexSetting.swift
+++ b/DietApp/Model/Logic/IndexSetting.swift
@@ -1,5 +1,5 @@
 //
-//  IndexSettingModel.swift
+//  IndexSetting.swift
 //  DietApp
 //
 //  Created by 川島真之 on 2023/07/08.
@@ -7,7 +7,7 @@
 
 import Foundation
 
-class IndexSettingModel {
+class IndexSetting {
   //月の前半か後半かによるindexの調整を行うメソッド
   //現在の日付が17日以降ならindexに1を返す
   func indexSetting() -> Int {


### PR DESCRIPTION
## issue
close #51 

## 概要
TopPageのMemo、PhotoセルのRealm登録の処理の修正と、IndexSettingModelのクラス、ファイル名の変更と、Documentsディレクトリ内のファイルの削除をする処理を追加した。

## やったこと

-  **TopPageのMemo、PhotoセルのRealm登録の処理の修正**
memoTextFieldに値が入力された時と、UIImagePickerControllerで写真の選択された時に現在の日付のRealmObjectが存在するか検索し、ある場合はデータの更新、ない場合は新たなRealmObjectを作る、という処理に修正した。

-  **IndexSettingModelのクラス、ファイルの名前の変更**
クラス名、ファイル名共にIndexSettingModelをIndexSettingに変更した。今後Model名の末尾にModelというキーワードは使用しないこととする。

-  **Documentsディレクトリ内のファイルの削除をする処理を追加**
UIImagePickerControllerで写真を選択した時に、現在の日付のRealmObjectが存在し、photoFileURLも登録されていたら、古い写真をDocumentsディレクトリないから削除するようにした。これによりユーザーが写真を更新した時に古い写真がDocuments内に溜まっていくことを防げる。

## 今後のタスク

- GraphPageのグラフ周りの処理を実装するために、作業を具体的にリストアップする。
- プログラミングノートの検討、試用。
- mainブランチに間違えてマージしてしまった内容をもとに戻せないか確認。
- テストについて確認。