### PR TITLE
Realmオブジェクトからデータを取り出し、エントリーポイントを作成できるようにした。

### DIFF
--- a/DietApp.xcodeproj/project.pbxproj
+++ b/DietApp.xcodeproj/project.pbxproj
@@ -12,7 +12,7 @@
 		60A4C6E95A42A5E6FBC4EC82 /* Pods_DietApp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 71B7CEEB90849C4649195C6F /* Pods_DietApp.framework */; };
 		FA0F9ECF2A2F0DEC00C7E888 /* GraphPageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA0F9ECE2A2F0DEC00C7E888 /* GraphPageViewController.swift */; };
 		FA0F9ED12A3016D100C7E888 /* UITabBarController+Orientation.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA0F9ED02A3016D100C7E888 /* UITabBarController+Orientation.swift */; };
-		FA11122C2A5923F6007353EA /* IndexSetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA11122B2A5923F6007353EA /* IndexSetting.swift */; };
+		FA11122C2A5923F6007353EA /* IndexSetter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA11122B2A5923F6007353EA /* IndexSetter.swift */; };
 		FA11122E2A592745007353EA /* Direction.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA11122D2A592745007353EA /* Direction.swift */; };
 		FA11879E2A22D2A5004577F8 /* PhotoTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA11879C2A22D2A5004577F8 /* PhotoTableViewCell.swift */; };
 		FA11879F2A22D2A5004577F8 /* PhotoTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = FA11879D2A22D2A5004577F8 /* PhotoTableViewCell.xib */; };
@@ -33,6 +33,7 @@
 		FA41A2F02A1C861E008DC83E /* TabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA41A2EF2A1C861E008DC83E /* TabBarController.swift */; };
 		FA41A2F22A1C8734008DC83E /* GraphViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA41A2F12A1C8734008DC83E /* GraphViewController.swift */; };
 		FA41A2F42A1C877E008DC83E /* SettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA41A2F32A1C877E008DC83E /* SettingsViewController.swift */; };
+		FA4D29A32A64F93900C2C5E6 /* GraphContentCreator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA4D29A22A64F93900C2C5E6 /* GraphContentCreator.swift */; };
 		FA68AF212A135F6F00B69D4A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA68AF202A135F6F00B69D4A /* AppDelegate.swift */; };
 		FA68AF232A135F6F00B69D4A /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA68AF222A135F6F00B69D4A /* SceneDelegate.swift */; };
 		FA68AF282A135F6F00B69D4A /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = FA68AF262A135F6F00B69D4A /* Main.storyboard */; };
@@ -81,7 +82,7 @@
 		F33E63A5ACE3D0B165D13D9B /* Pods-DietAppTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DietAppTests.debug.xcconfig"; path = "Target Support Files/Pods-DietAppTests/Pods-DietAppTests.debug.xcconfig"; sourceTree = "<group>"; };
 		FA0F9ECE2A2F0DEC00C7E888 /* GraphPageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphPageViewController.swift; sourceTree = "<group>"; };
 		FA0F9ED02A3016D100C7E888 /* UITabBarController+Orientation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITabBarController+Orientation.swift"; sourceTree = "<group>"; };
-		FA11122B2A5923F6007353EA /* IndexSetting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IndexSetting.swift; sourceTree = "<group>"; };
+		FA11122B2A5923F6007353EA /* IndexSetter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IndexSetter.swift; sourceTree = "<group>"; };
 		FA11122D2A592745007353EA /* Direction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Direction.swift; sourceTree = "<group>"; };
 		FA11879C2A22D2A5004577F8 /* PhotoTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoTableViewCell.swift; sourceTree = "<group>"; };
 		FA11879D2A22D2A5004577F8 /* PhotoTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = PhotoTableViewCell.xib; sourceTree = "<group>"; };
@@ -102,6 +103,7 @@
 		FA41A2EF2A1C861E008DC83E /* TabBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarController.swift; sourceTree = "<group>"; };
 		FA41A2F12A1C8734008DC83E /* GraphViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphViewController.swift; sourceTree = "<group>"; };
 		FA41A2F32A1C877E008DC83E /* SettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewController.swift; sourceTree = "<group>"; };
+		FA4D29A22A64F93900C2C5E6 /* GraphContentCreator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphContentCreator.swift; sourceTree = "<group>"; };
 		FA68AF1D2A135F6F00B69D4A /* DietApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = DietApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		FA68AF202A135F6F00B69D4A /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		FA68AF222A135F6F00B69D4A /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -187,7 +189,8 @@
 		FA1112302A59296B007353EA /* Logic */ = {
 			isa = PBXGroup;
 			children = (
-				FA11122B2A5923F6007353EA /* IndexSetting.swift */,
+				FA11122B2A5923F6007353EA /* IndexSetter.swift */,
+				FA4D29A22A64F93900C2C5E6 /* GraphContentCreator.swift */,
 				FA417BBF2A5C428E00B53A0F /* DateDataRealmSearcher.swift */,
 			);
 			path = Logic;
@@ -627,7 +630,7 @@
 				FA3142702A41671900254D60 /* TopNavigationController.swift in Sources */,
 				FA3142742A4194F300254D60 /* GraphNavigationController.swift in Sources */,
 				FA41A2EE2A1C8531008DC83E /* TopPageViewController.swift in Sources */,
-				FA11122C2A5923F6007353EA /* IndexSetting.swift in Sources */,
+				FA11122C2A5923F6007353EA /* IndexSetter.swift in Sources */,
 				FAFF6F592A21ACE40092A1A3 /* WeightTableViewCell.swift in Sources */,
 				FA41A2F42A1C877E008DC83E /* SettingsViewController.swift in Sources */,
 				FA3142722A418E9B00254D60 /* NavigationController+Orientation.swift in Sources */,
@@ -636,6 +639,7 @@
 				FABF36082A283CD0007D91DB /* GraphView.swift in Sources */,
 				FAFF6F602A21C60F0092A1A3 /* MemoTableViewCell.swift in Sources */,
 				FA32F4B82A32BD130058FD32 /* SettingsView.swift in Sources */,
+				FA4D29A32A64F93900C2C5E6 /* GraphContentCreator.swift in Sources */,
 				FAF1BB0F2A4D92FA00EFD25F /* DateData.swift in Sources */,
 				FA0F9ECF2A2F0DEC00C7E888 /* GraphPageViewController.swift in Sources */,
 				FA41A2F22A1C8734008DC83E /* GraphViewController.swift in Sources */,

--- a/DietApp/GraphPage/GraphPageViewController.swift
+++ b/DietApp/GraphPage/GraphPageViewController.swift
@@ -38,12 +38,14 @@ class GraphPageViewController: UIPageViewController {
     
     if let currentVC = self.viewControllers?.first{
       let currentVC = currentVC as! GraphViewController
+   
+      //月の前半か後半かによるindexの調整
+      let indexSetter = IndexSetter()
+      currentVC.index = indexSetter.indexSetting()
+ 
+      currentVC.graphSetting()
       //NavigationBarTittleの設定
       navigationBarTitleSetting(currentVC: currentVC)
-      //月の前半か後半かによるindexの調整
-      let indexSetting = IndexSetting()
-      let index = indexSetting.indexSetting()
-      currentVC.index = index
     }
     
     navigationBarButtonSetting()
@@ -126,13 +128,14 @@ extension GraphPageViewController {
     if currentVC.index % 2 == 0 {
       var firstDayString = ""
       var sixteenthDayString = ""
-      
+ 
       let value = currentVC.index/2
       modifiedDate = calendar.date(byAdding: .month, value: value, to: date)!
-      
+    
       //月の最初の日と１７日目をDate型で取得
       let firstDay = calendar.date(from: calendar.dateComponents([.year, .month], from: modifiedDate))!
-      let sixteenthDay = calendar.date(bySetting: .day, value: 16, of: modifiedDate)!
+      let sixteenthDay = calendar.date(bySetting: .day, value: 16, of: firstDay)!
+  
       //日付の表示形式の設定
       let dateFormatter = DateFormatter()
       dateFormatter.dateFormat = "M.d"
@@ -146,11 +149,17 @@ extension GraphPageViewController {
       var seventeenthDayString = ""
       var lastDayString = ""
       
+      
+      //
       //月の更新を行う。
       let value = (currentVC.index - 1)/2
       modifiedDate = calendar.date(byAdding: .month, value: value, to: date)!
-      
-      let seventeenthDay = calendar.date(bySetting: .day, value: 17, of: modifiedDate)!
+      //modifiedDateから直接その月の17日の日付を取得しようとすると、来月になってしまう。
+      //なので一旦、modifiedDateから月を抽出して、その月の最初の日を設定
+      let firstDayOfMonth = calendar.date(from: Calendar.current.dateComponents([.year, .month], from: modifiedDate))!
+      //その後その月の日付を17日設定する
+      let seventeenthDay = calendar.date(bySetting: .day, value: 17, of: firstDayOfMonth)!
+    
       //月末の取得は来月の月初を取得し、そこから１日戻すことで取得
       let add = DateComponents(month: 1, day: -1)
       let NextMonthFirstDay = calendar.date(from: calendar.dateComponents([.year, .month], from: modifiedDate))!

--- a/DietApp/GraphPage/GraphViewController.swift
+++ b/DietApp/GraphPage/GraphViewController.swift
@@ -88,25 +88,31 @@ class GraphViewController: UIViewController {
 extension GraphViewController {
   func graphSetting() {
     
-    let  sampleEntries = [
-      ChartDataEntry(x: 1, y: 15),
-      ChartDataEntry(x: 2, y: 20),
-      ChartDataEntry(x: 3, y: 15),
-      ChartDataEntry(x: 4, y: 25),
-      ChartDataEntry(x: 5, y: 18),
-      ChartDataEntry(x: 6, y: 22),
-      ChartDataEntry(x: 7, y: 27),
-      ChartDataEntry(x: 8, y: 32),
-      ChartDataEntry(x: 9, y: 26),
-      ChartDataEntry(x: 10, y: 28),
-      ChartDataEntry(x: 11, y: 30),
-      ChartDataEntry(x: 12, y: 27),
-      ChartDataEntry(x: 13, y: 24),
-      ChartDataEntry(x: 14, y: 31),
-      ChartDataEntry(x: 15, y: 25),
-  ]
+//    let  sampleEntries = [
+//      ChartDataEntry(x: 1, y: 15),
+//      ChartDataEntry(x: 2, y: 20),
+//      ChartDataEntry(x: 3, y: 15),
+//      ChartDataEntry(x: 4, y: 25),
+//      ChartDataEntry(x: 5, y: 18),
+//      ChartDataEntry(x: 6, y: 22),
+//      ChartDataEntry(x: 7, y: 27),
+//      ChartDataEntry(x: 8, y: 32),
+//      ChartDataEntry(x: 9, y: 26),
+//      ChartDataEntry(x: 10, y: 28),
+//      ChartDataEntry(x: 11, y: 30),
+//      ChartDataEntry(x: 12, y: 27),
+//      ChartDataEntry(x: 13, y: 24),
+//      ChartDataEntry(x: 14, y: 31),
+//      ChartDataEntry(x: 15, y: 25),
+//  ]
+//
+    let graphContetCreator = GraphContentCreator()
+    let dataEntries = graphContetCreator.createDataEntry(index: self.index)
     
-    let dataSet = LineChartDataSet(entries: sampleEntries)
+    let dataSet = LineChartDataSet(entries: dataEntries)
+    //エントリーポイントが作成されていない段階でのメッセージを非表示にする
+    graphView.graphAreaView.noDataText = ""
+   
     //エントリーポイント及びエントリーラインに関する調整
     
     //エントリーポイントとグラフ線の色を作成

--- a/DietApp/Model/Logic/GraphContentCreator.swift
+++ b/DietApp/Model/Logic/GraphContentCreator.swift
@@ -1,0 +1,73 @@
+//
+//  GraphContentCreator.swift
+//  DietApp
+//
+//  Created by 川島真之 on 2023/07/17.
+//
+
+import Foundation
+import RealmSwift
+import Charts
+
+class GraphContentCreator {
+  //エントリーポイントを作成するメソッド
+  func createDataEntry(index: Int) -> [ChartDataEntry] {
+    let realm = try! Realm()
+  
+    let calendar = Calendar.current
+    //現在の日付を取得
+    let date = Date()
+    //月の更新
+    let value = (index - 1)/2
+    let modifiedDate = calendar.date(byAdding: .month, value: value, to: date)!
+  
+    //現在の日付の月と年を取得
+    let month = calendar.component(.month, from: modifiedDate)
+    let year = calendar.component(.year, from: modifiedDate)
+    
+    var startDay: Int
+    var endDay: Int
+    
+    if index % 2 == 0 {
+      //indexが偶数だったら
+      startDay = 1
+      endDay = 16
+    } else {
+      //indexが奇数だったら
+      startDay = 17
+      //現在の月の最終日をendDayに代入
+      endDay = endOfMonth(modifiedDate)
+    }
+
+    var dataEntries: [ChartDataEntry] = []
+    
+    for day in startDay...endDay {
+      //現在の年、月、日を表すDateを作成。時間はその日の開始時刻(0時0分0秒）を取得。
+      let startOfCurrentDay = calendar.date(from: DateComponents(calendar: calendar, timeZone: TimeZone.current, year: year, month: month, day: day))!
+      //startOfCurrentDayに1日を足した日を作成。時間は開始時刻。
+      let startOfNextDay = calendar.date(byAdding: .day, value: 1, to: startOfCurrentDay)!
+      // 指定した日付のエントリを検索
+      let results = realm.objects(DateData.self)
+        .filter("date >= %@ && date < %@ && weight != 0", startOfCurrentDay, startOfNextDay)
+
+      // すべての結果をループし、チャートエントリーを作成
+      for result in results {
+        let entry = ChartDataEntry(x: Double(day), y: result.weight)
+          dataEntries.append(entry)
+      }
+    }
+    return dataEntries
+  }
+  //createEntryPointsのヘルパーメソッド
+  //現在の月の最終日を返すメソッド
+  //この処理だけ切り分ける必要があるのか後で確認
+  func endOfMonth(_ date: Date) -> Int {
+    let calendar = Calendar.current
+    //現在の月の日数を範囲として返す
+    //例えば2023年7月17日にこのメソッドを呼び出せば1..<32という値がrangeに代入される
+    let range = calendar.range(of: .day, in: .month, for: date)!
+    //rangeに値された範囲の要素数を返す
+    //つまり上の例でいうと31を返す
+    return range.count
+  }
+}

--- a/DietApp/Model/Logic/IndexSetter.swift
+++ b/DietApp/Model/Logic/IndexSetter.swift
@@ -1,5 +1,5 @@
 //
-//  IndexSetting.swift
+//  IndexSetter.swift
 //  DietApp
 //
 //  Created by 川島真之 on 2023/07/08.
@@ -7,7 +7,7 @@
 
 import Foundation
 
-class IndexSetting {
+class IndexSetter {
   //月の前半か後半かによるindexの調整を行うメソッド
   //現在の日付が17日以降ならindexに1を返す
   func indexSetting() -> Int {

--- a/DietApp/Model/RealmObject/DateData.swift
+++ b/DietApp/Model/RealmObject/DateData.swift
@@ -10,7 +10,7 @@ import RealmSwift
 
 class DateData: Object {
   @objc dynamic var date: Date = Date()
-  @objc dynamic var weight: String = ""
+  @objc dynamic var weight: Double = 0
   @objc dynamic var memoText: String = ""
   @objc dynamic var photoFileURL: String = ""
   @objc dynamic var imageOrientationRawValue: Int = Int()

--- a/DietApp/TopPage/TopViewController.swift
+++ b/DietApp/TopPage/TopViewController.swift
@@ -127,7 +127,8 @@ extension TopViewController: UITableViewDelegate,UITableViewDataSource {
       let resultsCount = results.count
       
       if resultsCount != 0 {
-        cell.weightTextField.text = results.first!.weight
+        let weightString = String(results.first!.weight)
+        cell.weightTextField.text = weightString
       }
       
       return cell
@@ -366,7 +367,7 @@ extension TopViewController: UITextFieldDelegate {
           //なのでレラムインスタンスを作り、データの上書き＝データを消す
           let realm = try! Realm()
           try! realm.write() {
-            results[0].weight = textField.text!
+            results[0].weight = 0
             print("体重データを消去しました")
           }
         }
@@ -378,14 +379,16 @@ extension TopViewController: UITextFieldDelegate {
           //今日の日付のデータを作る
           let dateData = DateData()
           dateData.date = self.date
-          dateData.weight = textField.text!
+          let weightDouble = Double(textField.text!)!
+          dateData.weight = weightDouble
           try! realm.write {
             realm.add(dateData)
           }
           //もしデータがあれば更新
         }else{
           try! realm.write() {
-            results[0].weight = textField.text!
+            let weightDouble = Double(textField.text!)!
+            results[0].weight = weightDouble
             print("体重を更新しました")
           }
         }


### PR DESCRIPTION
## issue
close #54

## 概要
グラフのエントリーポイントを作成するときに、Realmに対応するオブジェクトが存在するかどうか検索し、存在した場合そのオブジェクトを利用できるようにした。

## やったこと
- エントリーポイントを作成するメソッドが定義されたクラスを作成した。
- グラフページの画面遷移時に現在のページの日付範囲に対応するエントリーポイントを表示するようにした。
- エントリーポイントが存在しないページには"No Chart Data Available"というメッセージが表示されていたが、これを非表示にした。
- グラフページの日付範囲の表示がおかしくなっていたので修正した。
- indexを設定するクラスのクラス名とファイル名を変更した。

## 今後のタスク
- 日付の処理について体系的に勉強する。
- 今回作成した機能のリファクタリング。
- グラフ周りの細かい仕様の調査、決定。
データが存在しないページの表示方法、XとY軸の設定、グラフを設定するメソッドの呼び出しのタイミング
