### PR TITLE
グラフをエントリーポイントが作成されていない段階でも目盛りと軸線は表示されている状態にした。

### DIFF
--- a/DietApp.xcodeproj/project.pbxproj
+++ b/DietApp.xcodeproj/project.pbxproj
@@ -36,6 +36,8 @@
 		FA42FA2D2A6A4C1200C60F9E /* IndexSetterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA42FA2C2A6A4C1200C60F9E /* IndexSetterTests.swift */; };
 		FA42FA2F2A6B6CB700C60F9E /* DateDataRealmSearcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA42FA2E2A6B6CB700C60F9E /* DateDataRealmSearcherTests.swift */; };
 		FA42FA332A6CB76200C60F9E /* GraphContentCreatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA42FA322A6CB76200C60F9E /* GraphContentCreatorTests.swift */; };
+		FA42FA3A2A70B2DC00C60F9E /* DateRangeCalculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA42FA392A70B2DC00C60F9E /* DateRangeCalculator.swift */; };
+		FA42FA3C2A70BD4100C60F9E /* DateRangeCalculatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA42FA3B2A70BD4100C60F9E /* DateRangeCalculatorTests.swift */; };
 		FA4D29A32A64F93900C2C5E6 /* GraphContentCreator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA4D29A22A64F93900C2C5E6 /* GraphContentCreator.swift */; };
 		FA68AF212A135F6F00B69D4A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA68AF202A135F6F00B69D4A /* AppDelegate.swift */; };
 		FA68AF232A135F6F00B69D4A /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA68AF222A135F6F00B69D4A /* SceneDelegate.swift */; };
@@ -108,6 +110,8 @@
 		FA42FA2C2A6A4C1200C60F9E /* IndexSetterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IndexSetterTests.swift; sourceTree = "<group>"; };
 		FA42FA2E2A6B6CB700C60F9E /* DateDataRealmSearcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateDataRealmSearcherTests.swift; sourceTree = "<group>"; };
 		FA42FA322A6CB76200C60F9E /* GraphContentCreatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphContentCreatorTests.swift; sourceTree = "<group>"; };
+		FA42FA392A70B2DC00C60F9E /* DateRangeCalculator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateRangeCalculator.swift; sourceTree = "<group>"; };
+		FA42FA3B2A70BD4100C60F9E /* DateRangeCalculatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateRangeCalculatorTests.swift; sourceTree = "<group>"; };
 		FA4D29A22A64F93900C2C5E6 /* GraphContentCreator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphContentCreator.swift; sourceTree = "<group>"; };
 		FA68AF1D2A135F6F00B69D4A /* DietApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = DietApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		FA68AF202A135F6F00B69D4A /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -195,6 +199,7 @@
 			children = (
 				FA11122B2A5923F6007353EA /* IndexSetter.swift */,
 				FA4D29A22A64F93900C2C5E6 /* GraphContentCreator.swift */,
+				FA42FA392A70B2DC00C60F9E /* DateRangeCalculator.swift */,
 				FA417BBF2A5C428E00B53A0F /* DateDataRealmSearcher.swift */,
 			);
 			path = Logic;
@@ -295,6 +300,7 @@
 			isa = PBXGroup;
 			children = (
 				FA42FA322A6CB76200C60F9E /* GraphContentCreatorTests.swift */,
+				FA42FA3B2A70BD4100C60F9E /* DateRangeCalculatorTests.swift */,
 				FA42FA2E2A6B6CB700C60F9E /* DateDataRealmSearcherTests.swift */,
 				FA42FA2C2A6A4C1200C60F9E /* IndexSetterTests.swift */,
 			);
@@ -644,6 +650,7 @@
 				FA3142702A41671900254D60 /* TopNavigationController.swift in Sources */,
 				FA3142742A4194F300254D60 /* GraphNavigationController.swift in Sources */,
 				FA41A2EE2A1C8531008DC83E /* TopPageViewController.swift in Sources */,
+				FA42FA3A2A70B2DC00C60F9E /* DateRangeCalculator.swift in Sources */,
 				FA11122C2A5923F6007353EA /* IndexSetter.swift in Sources */,
 				FAFF6F592A21ACE40092A1A3 /* WeightTableViewCell.swift in Sources */,
 				FA41A2F42A1C877E008DC83E /* SettingsViewController.swift in Sources */,
@@ -671,6 +678,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				FA42FA2F2A6B6CB700C60F9E /* DateDataRealmSearcherTests.swift in Sources */,
+				FA42FA3C2A70BD4100C60F9E /* DateRangeCalculatorTests.swift in Sources */,
 				FA42FA332A6CB76200C60F9E /* GraphContentCreatorTests.swift in Sources */,
 				FA42FA2D2A6A4C1200C60F9E /* IndexSetterTests.swift in Sources */,
 			);

--- a/DietApp/GraphPage/GraphPageViewController.swift
+++ b/DietApp/GraphPage/GraphPageViewController.swift
@@ -39,7 +39,8 @@ class GraphPageViewController: UIPageViewController {
     if let currentVC = self.viewControllers?.first{
       let currentVC = currentVC as! GraphViewController
  
-      currentVC.graphSetting()
+//      currentVC.graphSetting()
+      currentVC.configureInitialGraph(index: currentVC.index)
       //NavigationBarTittleの設定
       navigationBarTitleSetting(currentVC: currentVC)
     }

--- a/DietApp/GraphPage/GraphViewController.swift
+++ b/DietApp/GraphPage/GraphViewController.swift
@@ -58,7 +58,8 @@ class GraphViewController: UIViewController {
       //画面の向きを変更させるために呼び出す。
       print(supportedInterfaceOrientations)
       
-      graphSetting()
+      //graphSetting()
+      configureInitialGraph(index: index)
     }
   
   override func loadView() {
@@ -182,4 +183,93 @@ extension GraphViewController {
     //グラフ内をダブルタップ及びピンチジェスチャーしたときのズームを出来ないようにする
     graphView.graphAreaView.doubleTapToZoomEnabled = false
   }
+  
+  func configureInitialGraph(index: Int){
+    // データエントリーポイントは初期では空にしておく
+    let dataEntries: [ChartDataEntry] = []
+    let dataSet = LineChartDataSet(entries: dataEntries)
+    
+    graphView.graphAreaView.noDataText = ""
+    
+    let dateRangeCalculator = DateRangeCalculator()
+    let results = dateRangeCalculator.calculateMonthHalfDayRange(index: index)
+    //X軸の設定
+    let xAxis = graphView.graphAreaView.xAxis
+    xAxis.labelPosition = .bottom
+    xAxis.axisMinimum = Double(results.startDay)// X軸の最小値
+    xAxis.axisMaximum = Double(results.endDay)// X軸の最大値
+   
+    let count = results.endDay - results.startDay + 1
+    xAxis.setLabelCount(count, force: true)
+
+    // Y軸の設定
+    let leftAxis = graphView.graphAreaView.leftAxis
+    leftAxis.axisMinimum = 0.0 // Y軸の最小値
+    leftAxis.axisMaximum = 100.0 // Y軸の最大値
+   
+    //エントリーポイント及びエントリーラインに関する調整
+    
+    //エントリーポイントとグラフ線の色を作成
+    let entryPointColor = UIColor(red: 72/255, green: 135/255, blue: 191/255, alpha: 1.0)
+    let graphLineColor = UIColor(red: 72/255, green: 135/255, blue: 191/255, alpha: 0.5)
+    //エントリーポイントを二重円ではなく、通常の円にする
+    dataSet.drawCircleHoleEnabled = false
+    //エントリーポイントのサイズの調整
+    dataSet.circleRadius = 5.0
+    //エントリーポイントの色を設定
+    dataSet.circleColors = [entryPointColor]
+    //グラフ線の太さの調整
+    dataSet.lineWidth = 1.5
+    //グラフ線の色を設定
+    dataSet.setColor(graphLineColor)
+    //エントリーポイントのラベルを非表示
+    dataSet.drawValuesEnabled = false
+    //エントリーポイントタップ時の十字のハイライトを非表示
+    dataSet.highlightEnabled = false
+    
+    //データのセット
+    let data = LineChartData(dataSet: dataSet)
+    graphView.graphAreaView.data = data
+    //凡例を非表示
+    graphView.graphAreaView.legend.enabled = false
+    
+    //グラフのX軸とY軸とグリッド線に関する調整
+    
+    //右のY軸のメモリを非表示
+    graphView.graphAreaView.rightAxis.drawLabelsEnabled = false
+    //X軸のメモリの表示を下に設定
+    graphView.graphAreaView.xAxis.labelPosition = .bottom
+    //Y軸のグリッド線を非表示
+    //※横画面の場合X軸とY軸が逆になる
+    graphView.graphAreaView.xAxis.drawGridLinesEnabled = false
+    //X軸のグリッド線を破線表示
+    graphView.graphAreaView.leftAxis.gridLineDashLengths = [2,2]
+    //X軸のグリッド線の太さ調整
+    graphView.graphAreaView.leftAxis.gridLineWidth = 0.3
+    //X軸のグリッド線の色を調整
+    graphView.graphAreaView.leftAxis.gridColor = .gray
+    //Y軸のメモリのラベルの太さを調整
+    graphView.graphAreaView.leftAxis.labelFont = UIFont.boldSystemFont(ofSize: 12)
+    //Y軸のメモリのラベルの色を調整
+    graphView.graphAreaView.leftAxis.labelTextColor = .gray
+    //右側からのグリッド線を非表示
+    //※chartsのY軸のグリッド線はデフォルトでは、右からと左からの二重の線となっているため、どちらかの線を非表示にしないと破線にならない
+    graphView.graphAreaView.rightAxis.drawGridLinesEnabled = false
+    //Y軸の左右の軸線を非表示
+    graphView.graphAreaView.leftAxis.drawAxisLineEnabled = false
+    graphView.graphAreaView.rightAxis.drawAxisLineEnabled = false
+    //X軸のメモリラベルの文字の太さを調整
+    graphView.graphAreaView.xAxis.labelFont = UIFont.boldSystemFont(ofSize: 12)
+    //X軸のメモリラベルの文字の色を調整
+    graphView.graphAreaView.xAxis.labelTextColor = .gray
+    //X軸のラベルの数を調整
+//    graphView.graphAreaView.xAxis.labelCount = dataSet.count
+    //Y軸の軸線と最初のエントリーポイントの間の余白を設定
+    graphView.graphAreaView.xAxis.spaceMin = 0.5
+    graphView.graphAreaView.xAxis.spaceMax = 0.5
+    //グラフ内をダブルタップ及びピンチジェスチャーしたときのズームを出来ないようにする
+    graphView.graphAreaView.doubleTapToZoomEnabled = false
+  }
+  
+  
 }

--- a/DietApp/Model/Logic/DateRangeCalculator.swift
+++ b/DietApp/Model/Logic/DateRangeCalculator.swift
@@ -1,0 +1,36 @@
+//
+//  DateRangeCalculator.swift
+//  DietApp
+//
+//  Created by 川島真之 on 2023/07/26.
+//
+
+import Foundation
+
+class DateRangeCalculator {
+  func calculateMonthHalfDayRange(index: Int,  date: Date = Date()) -> (startDay: Int, endDay: Int) {
+    let calendar = Calendar.current
+    //現在の日付を取得
+    //月の更新
+    let value = (index - 1)/2
+    let modifiedDate = calendar.date(byAdding: .month, value: value, to: date)!
+    
+    var startDay: Int
+    var endDay: Int
+    
+    if index % 2 == 0 {
+      //indexが偶数だったら
+      startDay = 1
+      endDay = 16
+    } else {
+      //indexが奇数だったら
+      startDay = 17
+      
+      let range = calendar.range(of: .day, in: .month, for: modifiedDate)!
+      //現在の月の最終日をendDayに代入
+      endDay = range.count
+    }
+    return (startDay: startDay, endDay: endDay)
+  }
+}
+

--- a/DietApp/Model/Logic/GraphContentCreator.swift
+++ b/DietApp/Model/Logic/GraphContentCreator.swift
@@ -30,23 +30,12 @@ class GraphContentCreator {
     let month = calendar.component(.month, from: modifiedDate)
     let year = calendar.component(.year, from: modifiedDate)
     
-    var startDay: Int
-    var endDay: Int
-    
-    if index % 2 == 0 {
-      //indexが偶数だったら
-      startDay = 1
-      endDay = 16
-    } else {
-      //indexが奇数だったら
-      startDay = 17
-      //現在の月の最終日をendDayに代入
-      endDay = endOfMonth(modifiedDate)
-    }
+    let dateRangeCalculator = DateRangeCalculator()
+    let results = dateRangeCalculator.calculateMonthHalfDayRange(index: index)
 
     var dataEntries: [ChartDataEntry] = []
     
-    for day in startDay...endDay {
+    for day in results.startDay...results.endDay {
       //現在の年、月、日を表すDateを作成。時間はその日の開始時刻(0時0分0秒）を取得。
       let startOfCurrentDay = calendar.date(from: DateComponents(calendar: calendar, timeZone: TimeZone.current, year: year, month: month, day: day))!
       //startOfCurrentDayに1日を足した日を作成。時間は開始時刻。
@@ -62,17 +51,5 @@ class GraphContentCreator {
       }
     }
     return dataEntries
-  }
-  //createEntryPointsのヘルパーメソッド
-  //現在の月の最終日を返すメソッド
-  //この処理だけ切り分ける必要があるのか後で確認
-  func endOfMonth(_ date: Date) -> Int {
-    let calendar = Calendar.current
-    //現在の月の日数を範囲として返す
-    //例えば2023年7月17日にこのメソッドを呼び出せば1..<32という値がrangeに代入される
-    let range = calendar.range(of: .day, in: .month, for: date)!
-    //rangeに値された範囲の要素数を返す
-    //つまり上の例でいうと31を返す
-    return range.count
   }
 }

--- a/DietAppTests/ModelTests/DateRangeCalculatorTests.swift
+++ b/DietAppTests/ModelTests/DateRangeCalculatorTests.swift
@@ -1,0 +1,65 @@
+//
+//  DateRangeCalculatorTests.swift
+//  DietAppTests
+//
+//  Created by 川島真之 on 2023/07/26.
+//
+
+import XCTest
+@testable import DietApp
+
+class DateRangeCalculatorTests: XCTestCase {
+  var dateRangeCalculator: DateRangeCalculator!
+  
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+  
+  override  func setUp() {
+    dateRangeCalculator = DateRangeCalculator()
+  }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+  //indexが偶数の場合のテスト
+  func testCalculateMonthHalfDayRangeWithEvenIndex() {
+    let results = dateRangeCalculator.calculateMonthHalfDayRange(index: 0)
+    // 期待される開始日を設定します。
+    let expectedStartDay = 1
+    // 期待される終了日を設定します。
+    let expectedEndDay = 16
+    
+    XCTAssertEqual(results.startDay, expectedStartDay)
+    XCTAssertEqual(results.endDay, expectedEndDay)
+  }
+  //indexが奇数の場合のテスト
+  func testCalculateMonthHalfDayRangeWithOddIndex() {
+    let date = DateComponents(calendar: Calendar.current, year: 2023, month: 7, day: 1).date!
+    let results = dateRangeCalculator.calculateMonthHalfDayRange(index: 1, date: date)
+    // 期待される開始日を設定します。
+    let expectedStartDay = 17
+    // 期待される終了日を設定します。
+    let expectedEndDay =  31
+    
+    XCTAssertEqual(results.startDay, expectedStartDay)
+    XCTAssertEqual(results.endDay, expectedEndDay)
+  }
+
+    func testExample() throws {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+        // Any test you write for XCTest can be annotated as throws and async.
+        // Mark your test throws to produce an unexpected failure when your test encounters an uncaught error.
+        // Mark your test async to allow awaiting for asynchronous code to complete. Check the results with assertions afterwards.
+    }
+
+    func testPerformanceExample() throws {
+        // This is an example of a performance test case.
+        self.measure {
+            // Put the code you want to measure the time of here.
+        }
+    }
+
+}

--- a/DietAppTests/ModelTests/GraphContentCreatorTests.swift
+++ b/DietAppTests/ModelTests/GraphContentCreatorTests.swift
@@ -67,18 +67,7 @@ class GraphContentCreatorTests: XCTestCase {
       let result = graphContentCreator.createDataEntry(index: 1)
       XCTAssertEqual(result.count, 0)
     }
-  //endOfMonth()のテスト
-  func testEndOfMonth() {
-    let graphContentCreator = GraphContentCreator(realm: self.inMemoryRealm)
-    
-    let dateString = "2023-09-01"
-    let dateFormatter = DateFormatter()
-    dateFormatter.dateFormat = "yyyy-MM-dd"
-    let date = dateFormatter.date(from: dateString)!
-    
-    let result = graphContentCreator.endOfMonth(date)
-    XCTAssertEqual(result, 30)
-  }
+
     func testExample() throws {
         // This is an example of a functional test case.
         // Use XCTAssert and related functions to verify your tests produce the correct results.


### PR DESCRIPTION
## issue
close #60

## 概要
グラフページのグラフをエントリーポイントが作成されていない段階でも、軸線と目盛りが表示されるようにした。目盛りは現在のページの日付の範囲と同じ範囲を表示している。

## やったこと
- 日付の範囲を計算するメソッドを作り、モデルに切り分けた。
- 上記の作業を行うために、既存のいくつかのメソッドを変更及び削除した。
- エントリーポイントが作成されていない段階でも、空のエントリーポイントセットを設定するようにした。
空であってもエントリーポイントセットが設定されていたらグラフの描画自体は行われる。ただ当然だが、エントリーポイントは表示されない。

## 内容
![スクリーンショット 2023-07-26 12 49 16](https://github.com/MasayukiKawashima/diet-app/assets/82994988/e40620b4-adce-4886-bd50-abd3a0256cfb)

![スクリーンショット 2023-07-26 12 50 34](https://github.com/MasayukiKawashima/diet-app/assets/82994988/54656c8e-03e5-4da4-92db-bcad01748456)

## 今後のタスク
- エントリーポイントが作成された時のグラフの更新処理の実装
- グラフのレイアウトの調整
