### PR TITLE
グラフの描画をする際に、Realmの検索結果によって処理を分岐させるようにした

### DIFF
--- a/DietApp/GraphPage/GraphPageViewController.swift
+++ b/DietApp/GraphPage/GraphPageViewController.swift
@@ -36,11 +36,10 @@ class GraphPageViewController: UIPageViewController {
     // Do any additional setup after loading the view.
     initGraphPageViewContoller()
     
+    
     if let currentVC = self.viewControllers?.first{
       let currentVC = currentVC as! GraphViewController
  
-//      currentVC.graphSetting()
-      currentVC.configureInitialGraph(index: currentVC.index)
       //NavigationBarTittleの設定
       navigationBarTitleSetting(currentVC: currentVC)
     }

--- a/DietApp/GraphPage/GraphViewController.swift
+++ b/DietApp/GraphPage/GraphViewController.swift
@@ -59,7 +59,7 @@ class GraphViewController: UIViewController {
       print(supportedInterfaceOrientations)
       
       //graphSetting()
-      configureInitialGraph(index: index)
+      configureGraph(index: index)
     }
   
   override func loadView() {
@@ -92,99 +92,7 @@ class GraphViewController: UIViewController {
 
 //グラフの設定
 extension GraphViewController {
-  func graphSetting() {
-    
-//    let  sampleEntries = [
-//      ChartDataEntry(x: 1, y: 15),
-//      ChartDataEntry(x: 2, y: 20),
-//      ChartDataEntry(x: 3, y: 15),
-//      ChartDataEntry(x: 4, y: 25),
-//      ChartDataEntry(x: 5, y: 18),
-//      ChartDataEntry(x: 6, y: 22),
-//      ChartDataEntry(x: 7, y: 27),
-//      ChartDataEntry(x: 8, y: 32),
-//      ChartDataEntry(x: 9, y: 26),
-//      ChartDataEntry(x: 10, y: 28),
-//      ChartDataEntry(x: 11, y: 30),
-//      ChartDataEntry(x: 12, y: 27),
-//      ChartDataEntry(x: 13, y: 24),
-//      ChartDataEntry(x: 14, y: 31),
-//      ChartDataEntry(x: 15, y: 25),
-//  ]
-//
-    let graphContetCreator = GraphContentCreator()
-    let dataEntries = graphContetCreator.createDataEntry(index: self.index)
-    
-    let dataSet = LineChartDataSet(entries: dataEntries)
-    //エントリーポイントが作成されていない段階でのメッセージを非表示にする
-    graphView.graphAreaView.noDataText = ""
-   
-    //エントリーポイント及びエントリーラインに関する調整
-    
-    //エントリーポイントとグラフ線の色を作成
-    let entryPointColor = UIColor(red: 72/255, green: 135/255, blue: 191/255, alpha: 1.0)
-    let graphLineColor = UIColor(red: 72/255, green: 135/255, blue: 191/255, alpha: 0.5)
-    //エントリーポイントを二重円ではなく、通常の円にする
-    dataSet.drawCircleHoleEnabled = false
-    //エントリーポイントのサイズの調整
-    dataSet.circleRadius = 5.0
-    //エントリーポイントの色を設定
-    dataSet.circleColors = [entryPointColor]
-    //グラフ線の太さの調整
-    dataSet.lineWidth = 1.5
-    //グラフ線の色を設定
-    dataSet.setColor(graphLineColor)
-    //エントリーポイントのラベルを非表示
-    dataSet.drawValuesEnabled = false
-    //エントリーポイントタップ時の十字のハイライトを非表示
-    dataSet.highlightEnabled = false
-    
-    
-    //データのセット
-    let data = LineChartData(dataSet: dataSet)
-    graphView.graphAreaView.data = data
-    //凡例を非表示
-    graphView.graphAreaView.legend.enabled = false
-    
-    //グラフのX軸とY軸とグリッド線に関する調整
-    
-    //右のY軸のメモリを非表示
-    graphView.graphAreaView.rightAxis.drawLabelsEnabled = false
-    //X軸のメモリの表示を下に設定
-    graphView.graphAreaView.xAxis.labelPosition = .bottom
-    //Y軸のグリッド線を非表示
-    //※横画面の場合X軸とY軸が逆になる
-    graphView.graphAreaView.xAxis.drawGridLinesEnabled = false
-    //X軸のグリッド線を破線表示
-    graphView.graphAreaView.leftAxis.gridLineDashLengths = [2,2]
-    //X軸のグリッド線の太さ調整
-    graphView.graphAreaView.leftAxis.gridLineWidth = 0.3
-    //X軸のグリッド線の色を調整
-    graphView.graphAreaView.leftAxis.gridColor = .gray
-    //Y軸のメモリのラベルの太さを調整
-    graphView.graphAreaView.leftAxis.labelFont = UIFont.boldSystemFont(ofSize: 12)
-    //Y軸のメモリのラベルの色を調整
-    graphView.graphAreaView.leftAxis.labelTextColor = .gray
-    //右側からのグリッド線を非表示
-    //※chartsのY軸のグリッド線はデフォルトでは、右からと左からの二重の線となっているため、どちらかの線を非表示にしないと破線にならない
-    graphView.graphAreaView.rightAxis.drawGridLinesEnabled = false
-    //Y軸の左右の軸線を非表示
-    graphView.graphAreaView.leftAxis.drawAxisLineEnabled = false
-    graphView.graphAreaView.rightAxis.drawAxisLineEnabled = false
-    //X軸のメモリラベルの文字の太さを調整
-    graphView.graphAreaView.xAxis.labelFont = UIFont.boldSystemFont(ofSize: 12)
-    //X軸のメモリラベルの文字の色を調整
-    graphView.graphAreaView.xAxis.labelTextColor = .gray
-    //X軸のラベルの数を調整
-    graphView.graphAreaView.xAxis.labelCount = dataSet.count
-    //Y軸の軸線と最初のエントリーポイントの間の余白を設定
-    graphView.graphAreaView.xAxis.spaceMin = 0.5
-    graphView.graphAreaView.xAxis.spaceMax = 0.5
-    //グラフ内をダブルタップ及びピンチジェスチャーしたときのズームを出来ないようにする
-    graphView.graphAreaView.doubleTapToZoomEnabled = false
-  }
-  
-  func configureInitialGraph(index: Int){
+  func configureDefaultGraph(index: Int){
     // データエントリーポイントは初期では空にしておく
     let dataEntries: [ChartDataEntry] = []
     let dataSet = LineChartDataSet(entries: dataEntries)
@@ -204,8 +112,8 @@ extension GraphViewController {
 
     // Y軸の設定
     let leftAxis = graphView.graphAreaView.leftAxis
-    leftAxis.axisMinimum = 0.0 // Y軸の最小値
-    leftAxis.axisMaximum = 100.0 // Y軸の最大値
+    leftAxis.axisMinimum = 40.0 // Y軸の最小値
+    leftAxis.axisMaximum = 80.0 // Y軸の最大値
    
     //エントリーポイント及びエントリーラインに関する調整
     
@@ -271,5 +179,94 @@ extension GraphViewController {
     graphView.graphAreaView.doubleTapToZoomEnabled = false
   }
   
-  
+  func configureGraph(index: Int){
+    let graphContetCreator = GraphContentCreator()
+    var dataEntries = graphContetCreator.createDataEntry(index: self.index)
+    
+    if dataEntries.count == 0 {
+      dataEntries = []
+    }
+    let dataSet = LineChartDataSet(entries: dataEntries)
+    
+    graphView.graphAreaView.noDataText = ""
+    
+    let dateRangeCalculator = DateRangeCalculator()
+    let results = dateRangeCalculator.calculateMonthHalfDayRange(index: index)
+    //X軸の設定
+    let xAxis = graphView.graphAreaView.xAxis
+    xAxis.labelPosition = .bottom
+    xAxis.axisMinimum = Double(results.startDay)// X軸の最小値
+    xAxis.axisMaximum = Double(results.endDay)// X軸の最大値
+   
+    let count = results.endDay - results.startDay + 1
+    xAxis.setLabelCount(count, force: true)
+
+    // Y軸の設定
+    let leftAxis = graphView.graphAreaView.leftAxis
+    leftAxis.axisMinimum = 40.0 // Y軸の最小値
+    leftAxis.axisMaximum = 80.0 // Y軸の最大値
+   
+    //エントリーポイント及びエントリーラインに関する調整
+    
+    //エントリーポイントとグラフ線の色を作成
+    let entryPointColor = UIColor(red: 72/255, green: 135/255, blue: 191/255, alpha: 1.0)
+    let graphLineColor = UIColor(red: 72/255, green: 135/255, blue: 191/255, alpha: 0.5)
+    //エントリーポイントを二重円ではなく、通常の円にする
+    dataSet.drawCircleHoleEnabled = false
+    //エントリーポイントのサイズの調整
+    dataSet.circleRadius = 5.0
+    //エントリーポイントの色を設定
+    dataSet.circleColors = [entryPointColor]
+    //グラフ線の太さの調整
+    dataSet.lineWidth = 1.5
+    //グラフ線の色を設定
+    dataSet.setColor(graphLineColor)
+    //エントリーポイントのラベルを非表示
+    dataSet.drawValuesEnabled = false
+    //エントリーポイントタップ時の十字のハイライトを非表示
+    dataSet.highlightEnabled = false
+    
+    //データのセット
+    let data = LineChartData(dataSet: dataSet)
+    graphView.graphAreaView.data = data
+    //凡例を非表示
+    graphView.graphAreaView.legend.enabled = false
+    
+    //グラフのX軸とY軸とグリッド線に関する調整
+    
+    //右のY軸のメモリを非表示
+    graphView.graphAreaView.rightAxis.drawLabelsEnabled = false
+    //X軸のメモリの表示を下に設定
+    graphView.graphAreaView.xAxis.labelPosition = .bottom
+    //Y軸のグリッド線を非表示
+    //※横画面の場合X軸とY軸が逆になる
+    graphView.graphAreaView.xAxis.drawGridLinesEnabled = false
+    //X軸のグリッド線を破線表示
+    graphView.graphAreaView.leftAxis.gridLineDashLengths = [2,2]
+    //X軸のグリッド線の太さ調整
+    graphView.graphAreaView.leftAxis.gridLineWidth = 0.3
+    //X軸のグリッド線の色を調整
+    graphView.graphAreaView.leftAxis.gridColor = .gray
+    //Y軸のメモリのラベルの太さを調整
+    graphView.graphAreaView.leftAxis.labelFont = UIFont.boldSystemFont(ofSize: 12)
+    //Y軸のメモリのラベルの色を調整
+    graphView.graphAreaView.leftAxis.labelTextColor = .gray
+    //右側からのグリッド線を非表示
+    //※chartsのY軸のグリッド線はデフォルトでは、右からと左からの二重の線となっているため、どちらかの線を非表示にしないと破線にならない
+    graphView.graphAreaView.rightAxis.drawGridLinesEnabled = false
+    //Y軸の左右の軸線を非表示
+    graphView.graphAreaView.leftAxis.drawAxisLineEnabled = false
+    graphView.graphAreaView.rightAxis.drawAxisLineEnabled = false
+    //X軸のメモリラベルの文字の太さを調整
+    graphView.graphAreaView.xAxis.labelFont = UIFont.boldSystemFont(ofSize: 12)
+    //X軸のメモリラベルの文字の色を調整
+    graphView.graphAreaView.xAxis.labelTextColor = .gray
+    //X軸のラベルの数を調整
+//    graphView.graphAreaView.xAxis.labelCount = dataSet.count
+    //Y軸の軸線と最初のエントリーポイントの間の余白を設定
+    graphView.graphAreaView.xAxis.spaceMin = 0.5
+    graphView.graphAreaView.xAxis.spaceMax = 0.5
+    //グラフ内をダブルタップ及びピンチジェスチャーしたときのズームを出来ないようにする
+    graphView.graphAreaView.doubleTapToZoomEnabled = false
+  }
 }

--- a/DietApp/TopPage/TopViewController.swift
+++ b/DietApp/TopPage/TopViewController.swift
@@ -73,6 +73,11 @@ class TopViewController: UIViewController {
     tapGesture.cancelsTouchesInView = false
     view.addGestureRecognizer(tapGesture)
     
+    let results = realm.objects(DateData.self)
+    print("aaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+    print(results)
+    print("aaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+    
     //スクロールできないようにする
     topView.tableView.isScrollEnabled = false
     //tableViewCellの高さの自動設定


### PR DESCRIPTION
## issue
close #62 

## 概要
グラフの描画処理を行う際に、現在のページの日付の範囲に対応するRealmオブジェクトが存在するかを検索し、存在しない場合はグラフの軸線と目盛りのみを描画し、存在した場合はそのRealmオブジェクトをもとにエントリーデータを作成し描画するようにした。

## やったこと
グラフの設定をする関数を新たに作成し、そこに上記の分岐を行う処理を実装した。

## 内容
確認のために7月17日〜31日にダミーのデータを入れた。
![スクリーンショット 2023-07-27 10 55 36](https://github.com/MasayukiKawashima/diet-app/assets/82994988/dc6ea379-e5c5-467b-9892-8c65761fa0cf)

## 今後のタスク
- グラフのエントリーポイントの表示バグの修正
8月1日〜17日にもダミーデータを入れたが、それらデータが9月1日〜16日のページに表示されている。
![スクリーンショット 2023-07-27 11 10 38](https://github.com/MasayukiKawashima/diet-app/assets/82994988/defc4eca-9f4c-4209-8334-a78abee10159)
