### PR TITLE
エントリーポイントの表示バグの修正 #64

### DIFF
--- a/DietApp/Model/Logic/GraphContentCreator.swift
+++ b/DietApp/Model/Logic/GraphContentCreator.swift
@@ -12,9 +12,11 @@ import Charts
 class GraphContentCreator {
   
   private let realm: Realm!
+  private let currentDate: Date!
   
-  init(realm: Realm = try! Realm()){
+  init(realm: Realm = try! Realm(), currentDate: Date = Date()){
     self.realm = realm
+    self.currentDate = currentDate
   }
   //エントリーポイントを作成するメソッド
   func createDataEntry(index: Int) -> [ChartDataEntry] {
@@ -23,9 +25,20 @@ class GraphContentCreator {
     //現在の日付を取得
     let date = Date()
     //月の更新
-    let value = (index - 1)/2
+   // print("\(index): indexの中身")
+    let value:Int!
+    //indexの値が偶数＝月の前半なら
+    if index % 2 == 0 {
+      value = index/2
+    }else{
+      //indexの値が奇数＝月の後半なら
+      value = (index - 1)/2
+    }
+    //print("\(value): valueの中身")
+    
     let modifiedDate = calendar.date(byAdding: .month, value: value, to: date)!
-  
+    print("\(modifiedDate): modifiedDateの中身")
+    
     //現在の日付の月と年を取得
     let month = calendar.component(.month, from: modifiedDate)
     let year = calendar.component(.year, from: modifiedDate)

--- a/DietApp/TopPage/TopViewController.swift
+++ b/DietApp/TopPage/TopViewController.swift
@@ -73,11 +73,6 @@ class TopViewController: UIViewController {
     tapGesture.cancelsTouchesInView = false
     view.addGestureRecognizer(tapGesture)
     
-    let results = realm.objects(DateData.self)
-    print("aaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
-    print(results)
-    print("aaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
-    
     //スクロールできないようにする
     topView.tableView.isScrollEnabled = false
     //tableViewCellの高さの自動設定

--- a/DietAppTests/ModelTests/GraphContentCreatorTests.swift
+++ b/DietAppTests/ModelTests/GraphContentCreatorTests.swift
@@ -55,18 +55,28 @@ class GraphContentCreatorTests: XCTestCase {
 //createDataEntry()のテスト
 //月の前半の場合のテスト
   func testCreateDataEntryBefore17() {
-      let graphContentCreator = GraphContentCreator(realm: self.inMemoryRealm)
-      let result = graphContentCreator.createDataEntry(index: 2)
-      XCTAssertEqual(result.count, 1)
-      XCTAssertEqual(result[0].y, 80.5)
-    }
+    let dateString = "2023-07-16"
+    let dateFormatter = DateFormatter()
+    dateFormatter.dateFormat = "yyyy-MM-dd"
+    let date = dateFormatter.date(from: dateString)!
+    
+    let graphContentCreator = GraphContentCreator(realm: self.inMemoryRealm, currentDate: date)
+    let result = graphContentCreator.createDataEntry(index: 0)
+    XCTAssertEqual(result.count, 1)
+    XCTAssertEqual(result[0].y, 80.5)
+  }
   
   //月の後半の場合のテスト
   func testCreateDataEntryAfter17() {
-      let graphContentCreator = GraphContentCreator(realm: self.inMemoryRealm)
-      let result = graphContentCreator.createDataEntry(index: 1)
-      XCTAssertEqual(result.count, 0)
-    }
+    let dateString = "2023-07-16"
+    let dateFormatter = DateFormatter()
+    dateFormatter.dateFormat = "yyyy-MM-dd"
+    let date = dateFormatter.date(from: dateString)!
+    
+    let graphContentCreator = GraphContentCreator(realm: self.inMemoryRealm, currentDate: date)
+    let result = graphContentCreator.createDataEntry(index: 1)
+    XCTAssertEqual(result.count, 0)
+  }
 
     func testExample() throws {
         // This is an example of a functional test case.


### PR DESCRIPTION
## issue
close #64

## 概要
8月のデータが9月のページに表示されてしまっているバグを修正した。

## バグの原因
createDataEntry()内の月の更新をするメソッドdate(byAdding:value:to:wrappingComponents:)において、そのメソッドに渡す引数であるvalueの計算が間違っていた。

修正前
`let value = (index - 1)/2`

修正後
```
let value:Int!

if index % 2 == 0 {
   value = index/2
 }else{
   value = (index - 1)/2
}
```
修正前は月の前半であってもindexから１を引いて２で割っていたため、計算が狂っていた。そのため、indexが偶数か奇数かで条件分岐するようにした。

## 今後のタスク
- ユーザーが体重を入力した後にすぐグラフページに移った場合、グラフが更新されていない問題を解決する。
現段階ではそのページのインスタンスが作られた段階でしかグラフの描画処理を行なっていないので、ユーザーが体重の入力が完了した段階でグラフを更新するようにする。
