### PR TITLE
設定ページのNavigationControllerの配置を行った

### DIFF
--- a/DietApp.xcodeproj/project.pbxproj
+++ b/DietApp.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		FA11879F2A22D2A5004577F8 /* PhotoTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = FA11879D2A22D2A5004577F8 /* PhotoTableViewCell.xib */; };
 		FA1187A22A22F652004577F8 /* AdTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA1187A02A22F652004577F8 /* AdTableViewCell.swift */; };
 		FA1187A32A22F652004577F8 /* AdTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = FA1187A12A22F652004577F8 /* AdTableViewCell.xib */; };
+		FA24A86F2CA566950082AF19 /* SettingsNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA24A86E2CA566950082AF19 /* SettingsNavigationController.swift */; };
 		FA3142702A41671900254D60 /* TopNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA31426F2A41671900254D60 /* TopNavigationController.swift */; };
 		FA3142742A4194F300254D60 /* GraphNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA3142732A4194F300254D60 /* GraphNavigationController.swift */; };
 		FA32F4B62A32BCF50058FD32 /* SettingsView.xib in Resources */ = {isa = PBXBuildFile; fileRef = FA32F4B52A32BCF50058FD32 /* SettingsView.xib */; };
@@ -98,6 +99,7 @@
 		FA11879D2A22D2A5004577F8 /* PhotoTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = PhotoTableViewCell.xib; sourceTree = "<group>"; };
 		FA1187A02A22F652004577F8 /* AdTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdTableViewCell.swift; sourceTree = "<group>"; };
 		FA1187A12A22F652004577F8 /* AdTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = AdTableViewCell.xib; sourceTree = "<group>"; };
+		FA24A86E2CA566950082AF19 /* SettingsNavigationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsNavigationController.swift; sourceTree = "<group>"; };
 		FA31426F2A41671900254D60 /* TopNavigationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopNavigationController.swift; sourceTree = "<group>"; };
 		FA3142732A4194F300254D60 /* GraphNavigationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphNavigationController.swift; sourceTree = "<group>"; };
 		FA32F4B52A32BCF50058FD32 /* SettingsView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SettingsView.xib; sourceTree = "<group>"; };
@@ -307,6 +309,7 @@
 		FA41A2FE2A1C8973008DC83E /* SettingsPage */ = {
 			isa = PBXGroup;
 			children = (
+				FA24A86E2CA566950082AF19 /* SettingsNavigationController.swift */,
 				FA41A2F32A1C877E008DC83E /* SettingsViewController.swift */,
 			);
 			path = SettingsPage;
@@ -663,6 +666,7 @@
 			files = (
 				FA32F4C42A32BFCF0058FD32 /* NotificationTableViewCell.swift in Sources */,
 				FA1187A22A22F652004577F8 /* AdTableViewCell.swift in Sources */,
+				FA24A86F2CA566950082AF19 /* SettingsNavigationController.swift in Sources */,
 				FA41A2EC2A1C84CE008DC83E /* TopViewController.swift in Sources */,
 				FA32F4C82A32C0900058FD32 /* ThemeColorTableViewCell.swift in Sources */,
 				FA3142702A41671900254D60 /* TopNavigationController.swift in Sources */,

--- a/DietApp/AppDelegate.swift
+++ b/DietApp/AppDelegate.swift
@@ -31,8 +31,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         }
       }
     }
-    //設定画面はまだNavigationConrtrollerを実装していないので、デフォルトの向きになる
-    //デフォルトをportraitにすることでも期待した動作をしているが、ロジックが汚いので修正予定
     return .portrait // デフォルトの向き
   }
   

--- a/DietApp/SettingsPage/SettingsNavigationController.swift
+++ b/DietApp/SettingsPage/SettingsNavigationController.swift
@@ -1,0 +1,29 @@
+//
+//  SettingsNavigationController.swift
+//  DietApp
+//
+//  Created by 川島真之 on 2024/09/26.
+//
+
+import UIKit
+
+class SettingsNavigationController: UINavigationController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Do any additional setup after loading the view.
+    }
+    
+
+    /*
+    // MARK: - Navigation
+
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // Get the new view controller using segue.destination.
+        // Pass the selected object to the new view controller.
+    }
+    */
+
+}

--- a/DietApp/SettingsPage/SettingsViewController.swift
+++ b/DietApp/SettingsPage/SettingsViewController.swift
@@ -14,6 +14,10 @@ class SettingsViewController: UIViewController {
     return .portrait
   }
   
+  override var preferredInterfaceOrientationForPresentation: UIInterfaceOrientation {
+    .portrait
+  }
+  
   var TableViewCellHeight:CGFloat = 60.0
   //cell周り設定用の列挙体
   enum SettingPageCell:Int {
@@ -27,11 +31,10 @@ class SettingsViewController: UIViewController {
         // Do any additional setup after loading the view.
       settingsView.tableView.delegate = self
       settingsView.tableView.dataSource = self
-      settingsView.navigationBar.delegate = self
       //セルの区切り線を左端まで伸ばす
       settingsView.tableView.separatorInset = UIEdgeInsets.zero
       //navigationBarのタイトルの設定
-      settingsView.navigationBar.titleTextAttributes = [NSAttributedString.Key.font: UIFont(name: "Thonburi-Bold", size: 20)!]
+//      settingsView.navigationBar.titleTextAttributes = [NSAttributedString.Key.font: UIFont(name: "Thonburi-Bold", size: 20)!]
       //スクロールできないようにする
       settingsView.tableView.isScrollEnabled = false
       //セルの高さの自動設定
@@ -54,13 +57,6 @@ class SettingsViewController: UIViewController {
     }
     */
 
-}
-//navigationBarの設定
-extension SettingsViewController: UINavigationBarDelegate {
-  //navigationBarをステータスバーを覆うように表示
-  func position(for bar: UIBarPositioning) -> UIBarPosition {
-    return .topAttached
-  }
 }
 //tableViewの設定
 extension SettingsViewController: UITableViewDelegate,UITableViewDataSource {
@@ -101,7 +97,7 @@ extension SettingsViewController {
     
     let titleText = "設定"
     
-    let customTitleView = UIView(frame: CGRect(x: 0, y: 0, width: 200, height: settingsView.navigationBar.frame.size.height))
+    let customTitleView = UIView(frame: CGRect(x: 0, y: 0, width: 200, height: 44))
     
     let titleTextLabel = UILabel(frame: CGRect(x: 0, y: 0, width: 100, height: 22))
     titleTextLabel.text = titleText
@@ -117,6 +113,6 @@ extension SettingsViewController {
       titleTextLabel.centerXAnchor.constraint(equalTo: customTitleView.centerXAnchor),
       titleTextLabel.centerYAnchor.constraint(equalTo: customTitleView.centerYAnchor)
     ])
-    settingsView.navigationItem.titleView = customTitleView
+    self.navigationItem.titleView = customTitleView
   }
 }

--- a/DietApp/View/Base.lproj/Main.storyboard
+++ b/DietApp/View/Base.lproj/Main.storyboard
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="F92-bx-bHI">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23094" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="F92-bx-bHI">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23084"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -44,7 +45,7 @@
             </objects>
             <point key="canvasLocation" x="2360.8695652173915" y="695.75892857142856"/>
         </scene>
-        <!--設定-->
+        <!--Settings View Controller-->
         <scene sceneID="IRs-ol-4oz">
             <objects>
                 <viewController id="8AN-9h-T1k" customClass="SettingsViewController" customModule="DietApp" customModuleProvider="target" sceneMemberID="viewController">
@@ -54,11 +55,11 @@
                         <viewLayoutGuide key="safeArea" id="499-cf-yd9"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     </view>
-                    <tabBarItem key="tabBarItem" title="設定" image="gearshape" catalog="system" id="yok-7R-Obr"/>
+                    <navigationItem key="navigationItem" id="ka6-aK-8q0"/>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="QSw-Qy-dib" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="572" y="1392"/>
+            <point key="canvasLocation" x="1481.1594202898552" y="1391.5178571428571"/>
         </scene>
         <!--Top View Controller-->
         <scene sceneID="42X-Xj-WhJ">
@@ -87,7 +88,7 @@
                     <connections>
                         <segue destination="3an-lQ-V07" kind="relationship" relationship="viewControllers" id="BL4-C8-gr4"/>
                         <segue destination="0pI-mw-1KE" kind="relationship" relationship="viewControllers" id="ehO-hi-S0E"/>
-                        <segue destination="8AN-9h-T1k" kind="relationship" relationship="viewControllers" id="jfU-KF-qc7"/>
+                        <segue destination="Vvf-7G-zEG" kind="relationship" relationship="viewControllers" id="jfU-KF-qc7"/>
                     </connections>
                 </tabBarController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="vtR-cH-93i" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
@@ -101,7 +102,7 @@
                     <tabBarItem key="tabBarItem" title="トップ" image="house" catalog="system" selectedImage="house" id="noS-pd-IpZ"/>
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="xsN-Db-zYa">
-                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
+                        <rect key="frame" x="0.0" y="48" width="414" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <navigationBarAppearance key="standardAppearance"/>
                         <navigationBarAppearance key="scrollEdgeAppearance">
@@ -124,7 +125,7 @@
                     <tabBarItem key="tabBarItem" title="グラフ" image="chart.xyaxis.line" catalog="system" id="qx3-1w-E1q"/>
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="Ml3-ha-DEn">
-                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
+                        <rect key="frame" x="0.0" y="48" width="414" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <navigationBarAppearance key="standardAppearance"/>
                         <navigationBarAppearance key="scrollEdgeAppearance">
@@ -140,19 +141,45 @@
             </objects>
             <point key="canvasLocation" x="570" y="696"/>
         </scene>
+        <!--設定-->
+        <scene sceneID="R54-Zi-dbb">
+            <objects>
+                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="Vvf-7G-zEG" customClass="SettingsNavigationController" customModule="DietApp" customModuleProvider="target" sceneMemberID="viewController">
+                    <tabBarItem key="tabBarItem" title="設定" image="gearshape" catalog="system" id="yok-7R-Obr"/>
+                    <toolbarItems/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="jd2-7p-XMa">
+                        <rect key="frame" x="0.0" y="48" width="414" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                        <navigationBarAppearance key="standardAppearance"/>
+                        <navigationBarAppearance key="scrollEdgeAppearance">
+                            <color key="backgroundColor" systemColor="systemGray6Color"/>
+                        </navigationBarAppearance>
+                    </navigationBar>
+                    <nil name="viewControllers"/>
+                    <connections>
+                        <segue destination="8AN-9h-T1k" kind="relationship" relationship="rootViewController" id="QvR-I9-QzY"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Xzd-ca-TY6" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="571.01449275362324" y="1391.5178571428571"/>
+        </scene>
     </scenes>
     <resources>
-        <image name="chart.xyaxis.line" catalog="system" width="128" height="101"/>
-        <image name="gearshape" catalog="system" width="128" height="121"/>
-        <image name="house" catalog="system" width="128" height="106"/>
+        <image name="chart.xyaxis.line" catalog="system" width="128" height="102"/>
+        <image name="gearshape" catalog="system" width="128" height="123"/>
+        <image name="house" catalog="system" width="128" height="104"/>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>
+        <systemColor name="systemGray6Color">
+            <color red="0.94901960780000005" green="0.94901960780000005" blue="0.96862745100000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
         <systemColor name="systemGroupedBackgroundColor">
-            <color red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.94901960780000005" green="0.94901960780000005" blue="0.96862745100000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
         <systemColor name="tertiarySystemGroupedBackgroundColor">
-            <color red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.94901960780000005" green="0.94901960780000005" blue="0.96862745100000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/DietApp/View/SettingsPage/SettingsView.swift
+++ b/DietApp/View/SettingsPage/SettingsView.swift
@@ -11,10 +11,6 @@ class SettingsView: UIView {
   
   let cellIdentifiers = ["ThemeColorTableViewCell","NotificationTableViewCell"]
   
-  @IBOutlet weak var navigationBar: UINavigationBar!
-  
-  @IBOutlet weak var navigationItem: UINavigationItem!
-  
   @IBOutlet weak var tableView: UITableView!{
     didSet{
       //各セルの登録

--- a/DietApp/View/SettingsPage/SettingsView.xib
+++ b/DietApp/View/SettingsPage/SettingsView.xib
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="23094" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23084"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -10,8 +11,6 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="SettingsView" customModule="DietApp" customModuleProvider="target">
             <connections>
-                <outlet property="navigationBar" destination="1q1-rg-XQX" id="t4P-Z7-vuy"/>
-                <outlet property="navigationItem" destination="XNq-DC-Uj1" id="GeI-uS-Owx"/>
                 <outlet property="tableView" destination="RmB-YX-ePb" id="4Xg-C3-kCc"/>
             </connections>
         </placeholder>
@@ -20,30 +19,17 @@
             <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <navigationBar contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="1q1-rg-XQX">
-                    <rect key="frame" x="0.0" y="44" width="414" height="44"/>
-                    <color key="backgroundColor" systemColor="systemCyanColor"/>
-                    <constraints>
-                        <constraint firstAttribute="height" constant="44" id="eeW-iL-Gmv"/>
-                    </constraints>
-                    <items>
-                        <navigationItem title="設定" id="XNq-DC-Uj1"/>
-                    </items>
-                </navigationBar>
                 <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="RmB-YX-ePb">
-                    <rect key="frame" x="0.0" y="88" width="414" height="774"/>
+                    <rect key="frame" x="0.0" y="48" width="414" height="814"/>
                     <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                 </tableView>
             </subviews>
             <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
             <color key="backgroundColor" systemColor="systemBackgroundColor"/>
             <constraints>
-                <constraint firstItem="RmB-YX-ePb" firstAttribute="top" secondItem="1q1-rg-XQX" secondAttribute="bottom" id="2XU-Us-FsM"/>
-                <constraint firstItem="1q1-rg-XQX" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" id="5oo-UX-U6y"/>
-                <constraint firstItem="RmB-YX-ePb" firstAttribute="bottom" secondItem="vUN-kp-3ea" secondAttribute="bottom" id="BPL-Gq-gCe"/>
-                <constraint firstItem="1q1-rg-XQX" firstAttribute="trailing" secondItem="vUN-kp-3ea" secondAttribute="trailing" id="QJ7-jW-uHD"/>
+                <constraint firstItem="RmB-YX-ePb" firstAttribute="bottom" secondItem="vUN-kp-3ea" secondAttribute="bottom" id="DhO-gQ-EXH"/>
                 <constraint firstItem="RmB-YX-ePb" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" id="SC0-8T-Q0k"/>
-                <constraint firstItem="1q1-rg-XQX" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" id="ljJ-12-mq8"/>
+                <constraint firstItem="RmB-YX-ePb" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" id="cQR-E4-xZW"/>
                 <constraint firstItem="RmB-YX-ePb" firstAttribute="trailing" secondItem="vUN-kp-3ea" secondAttribute="trailing" id="m82-KN-aSU"/>
             </constraints>
             <point key="canvasLocation" x="131.8840579710145" y="48.883928571428569"/>
@@ -52,9 +38,6 @@
     <resources>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-        </systemColor>
-        <systemColor name="systemCyanColor">
-            <color red="0.19607843137254902" green="0.67843137254901964" blue="0.90196078431372551" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>


### PR DESCRIPTION
## issue
close #76

## やったこと
これまでは設定ページの上部にNavigationBar単体を配置していたがこれを廃止して、NavigationController＋NavigationBarの構成に置き換えた。加えて背景色の変更やNavigationBarのタイトルを制御するメソッドを編集した。

<img width="316" alt="スクリーンショット 2024-09-26 22 20 33" src="https://github.com/user-attachments/assets/b40e5b02-5ab3-4aef-be0e-2e1ee46575e7">

## やらなかったこと
画面の向きと回転を制御するメソッドのテストはしていない。
次以降のissueで行う。
