### PR TITLE
画面の向きを制御するメソッドのテスト作業終了

### DIFF
--- a/DietApp.xcodeproj/project.pbxproj
+++ b/DietApp.xcodeproj/project.pbxproj
@@ -19,6 +19,9 @@
 		FA1187A22A22F652004577F8 /* AdTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA1187A02A22F652004577F8 /* AdTableViewCell.swift */; };
 		FA1187A32A22F652004577F8 /* AdTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = FA1187A12A22F652004577F8 /* AdTableViewCell.xib */; };
 		FA24A86F2CA566950082AF19 /* SettingsNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA24A86E2CA566950082AF19 /* SettingsNavigationController.swift */; };
+		FA24A8732CA66F110082AF19 /* OrientationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA24A8722CA66F110082AF19 /* OrientationManager.swift */; };
+		FA24A8792CA6C8EF0082AF19 /* GraphNavigationControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA24A8782CA6C8EF0082AF19 /* GraphNavigationControllerTests.swift */; };
+		FA24A87E2CA6EC100082AF19 /* AppDelegateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA24A87D2CA6EC100082AF19 /* AppDelegateTests.swift */; };
 		FA3142702A41671900254D60 /* TopNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA31426F2A41671900254D60 /* TopNavigationController.swift */; };
 		FA3142742A4194F300254D60 /* GraphNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA3142732A4194F300254D60 /* GraphNavigationController.swift */; };
 		FA32F4B62A32BCF50058FD32 /* SettingsView.xib in Resources */ = {isa = PBXBuildFile; fileRef = FA32F4B52A32BCF50058FD32 /* SettingsView.xib */; };
@@ -100,6 +103,9 @@
 		FA1187A02A22F652004577F8 /* AdTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdTableViewCell.swift; sourceTree = "<group>"; };
 		FA1187A12A22F652004577F8 /* AdTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = AdTableViewCell.xib; sourceTree = "<group>"; };
 		FA24A86E2CA566950082AF19 /* SettingsNavigationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsNavigationController.swift; sourceTree = "<group>"; };
+		FA24A8722CA66F110082AF19 /* OrientationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrientationManager.swift; sourceTree = "<group>"; };
+		FA24A8782CA6C8EF0082AF19 /* GraphNavigationControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphNavigationControllerTests.swift; sourceTree = "<group>"; };
+		FA24A87D2CA6EC100082AF19 /* AppDelegateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegateTests.swift; sourceTree = "<group>"; };
 		FA31426F2A41671900254D60 /* TopNavigationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopNavigationController.swift; sourceTree = "<group>"; };
 		FA3142732A4194F300254D60 /* GraphNavigationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphNavigationController.swift; sourceTree = "<group>"; };
 		FA32F4B52A32BCF50058FD32 /* SettingsView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SettingsView.xib; sourceTree = "<group>"; };
@@ -217,6 +223,7 @@
 				FA4D29A22A64F93900C2C5E6 /* GraphContentCreator.swift */,
 				FA42FA392A70B2DC00C60F9E /* DateRangeCalculator.swift */,
 				FA417BBF2A5C428E00B53A0F /* DateDataRealmSearcher.swift */,
+				FA24A8722CA66F110082AF19 /* OrientationManager.swift */,
 			);
 			path = Logic;
 			sourceTree = "<group>";
@@ -229,6 +236,22 @@
 				FA42FA592A91BD5700C60F9E /* GraphDateManager.swift */,
 			);
 			path = Data;
+			sourceTree = "<group>";
+		};
+		FA24A8742CA6C2100082AF19 /* AppDelegateTests */ = {
+			isa = PBXGroup;
+			children = (
+				FA24A87D2CA6EC100082AF19 /* AppDelegateTests.swift */,
+			);
+			path = AppDelegateTests;
+			sourceTree = "<group>";
+		};
+		FA24A8752CA6C2450082AF19 /* GraphPageTests */ = {
+			isa = PBXGroup;
+			children = (
+				FA24A8782CA6C8EF0082AF19 /* GraphNavigationControllerTests.swift */,
+			);
+			path = GraphPageTests;
 			sourceTree = "<group>";
 		};
 		FA32F4B02A32BBAE0058FD32 /* SettingsPage */ = {
@@ -367,6 +390,8 @@
 		FA68AF362A135F7200B69D4A /* DietAppTests */ = {
 			isa = PBXGroup;
 			children = (
+				FA24A8752CA6C2450082AF19 /* GraphPageTests */,
+				FA24A8742CA6C2100082AF19 /* AppDelegateTests */,
 				FA42FA342A6CE85600C60F9E /* ModelTests */,
 			);
 			path = DietAppTests;
@@ -686,6 +711,7 @@
 				FA42FA402A76173D00C60F9E /* KGAxisValueFormatter.swift in Sources */,
 				FA4D29A32A64F93900C2C5E6 /* GraphContentCreator.swift in Sources */,
 				FA42FA542A82166500C60F9E /* CustomMarkerViewController.swift in Sources */,
+				FA24A8732CA66F110082AF19 /* OrientationManager.swift in Sources */,
 				FA42FA5A2A91BD5700C60F9E /* GraphDateManager.swift in Sources */,
 				FAF1BB0F2A4D92FA00EFD25F /* DateData.swift in Sources */,
 				FA0F9ECF2A2F0DEC00C7E888 /* GraphPageViewController.swift in Sources */,
@@ -706,8 +732,10 @@
 			files = (
 				FA42FA2F2A6B6CB700C60F9E /* DateDataRealmSearcherTests.swift in Sources */,
 				FA42FA3C2A70BD4100C60F9E /* DateRangeCalculatorTests.swift in Sources */,
+				FA24A8792CA6C8EF0082AF19 /* GraphNavigationControllerTests.swift in Sources */,
 				FA42FA332A6CB76200C60F9E /* GraphContentCreatorTests.swift in Sources */,
 				FA42FA2D2A6A4C1200C60F9E /* IndexSetterTests.swift in Sources */,
+				FA24A87E2CA6EC100082AF19 /* AppDelegateTests.swift in Sources */,
 				FA42FA4A2A7F3BE600C60F9E /* MonthAdjusterTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/DietApp/AppDelegate.swift
+++ b/DietApp/AppDelegate.swift
@@ -11,13 +11,8 @@ import UIKit
 class AppDelegate: UIResponder, UIApplicationDelegate {
   
   var window: UIWindow?
-  
-  func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-    
-    return true
-  }
-  //ViewControllerの向きの設定
-  func application(_ application: UIApplication, supportedInterfaceOrientationsFor window: UIWindow?) -> UIInterfaceOrientationMask {
+  //画面の向きを設定するメソッド
+  func supportedInterfaceOrientationsForTopViewController(window: UIWindow?) -> UIInterfaceOrientationMask {
     if let rootViewController = window?.rootViewController {
       // TabBarControllerを取得
       if let tabBarController = rootViewController as? UITabBarController {
@@ -31,7 +26,16 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         }
       }
     }
-    return .portrait // デフォルトの向き
+    return .portrait // デフォルトは縦向き
+  }
+  
+  func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+    
+    return true
+  }
+  //ViewControllerの向きの設定
+  func application(_ application: UIApplication, supportedInterfaceOrientationsFor window: UIWindow?) -> UIInterfaceOrientationMask {
+    supportedInterfaceOrientationsForTopViewController(window: window)
   }
   
   // MARK: UISceneSession Lifecycle

--- a/DietApp/GraphPage/GraphNavigationController.swift
+++ b/DietApp/GraphPage/GraphNavigationController.swift
@@ -17,7 +17,7 @@ class GraphNavigationController: UINavigationController {
     return .landscapeLeft
   }
   //画面回転
-  private func rotate() {
+  private func graphViewControllersRotate() {
     if #available(iOS 16.0, *) {
       guard let windowScene = view.window?.windowScene else {
         return
@@ -25,7 +25,7 @@ class GraphNavigationController: UINavigationController {
       windowScene.requestGeometryUpdate(.iOS(interfaceOrientations: .landscapeLeft))
       setNeedsUpdateOfSupportedInterfaceOrientations()
     } else {
-      UIDevice.current.setValue(3, forKey: "orientation")
+      UIDevice.current.setValue(UIInterfaceOrientation.landscapeLeft.rawValue, forKey: "orientation")
     }
   }
   
@@ -35,7 +35,7 @@ class GraphNavigationController: UINavigationController {
   }
   
   override func viewWillLayoutSubviews() {
-    rotate()
+    graphViewControllersRotate()
   }
   
   /*

--- a/DietApp/Model/Logic/OrientationManager.swift
+++ b/DietApp/Model/Logic/OrientationManager.swift
@@ -1,0 +1,11 @@
+//
+//  OrientationManager.swift
+//  DietApp
+//
+//  Created by 川島真之 on 2024/09/27.
+//
+
+import Foundation
+
+class OrientationManager {
+}

--- a/DietAppTests/AppDelegateTests/AppDelegateTests.swift
+++ b/DietAppTests/AppDelegateTests/AppDelegateTests.swift
@@ -1,0 +1,84 @@
+//
+//  AppDelegateTests.swift
+//  DietAppTests
+//
+//  Created by 川島真之 on 2024/09/27.
+//
+
+import XCTest
+@testable import DietApp
+
+final class AppDelegateTests: XCTestCase {
+  
+  var appDelegate: AppDelegate!
+  var window: UIWindow!
+  var tabBarController: TabBarController!
+  var topNavigationController: TopNavigationController!
+  var topPageviewController: TopPageViewController!
+  var topViewController: TopViewController!
+  var graphNavigationController: GraphNavigationController!
+  var graphPageViewController: GraphPageViewController!
+  var graphViewController: GraphViewController!
+  var settingsNavigationController: SettingsNavigationController!
+  var settingsViewController: SettingsViewController!
+  
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+  
+  override func setUp() {
+    super.setUp()
+    
+    appDelegate = UIApplication.shared.delegate as? AppDelegate
+    self.window = UIWindow()
+    self.tabBarController = TabBarController()
+    self.topNavigationController = TopNavigationController()
+    self.topPageviewController = TopPageViewController()
+    self.topViewController = TopViewController()
+    self.graphNavigationController = GraphNavigationController()
+    self.graphPageViewController = GraphPageViewController()
+    self.graphViewController = GraphViewController()
+    self.settingsNavigationController = SettingsNavigationController()
+    self.settingsViewController = SettingsViewController()
+  }
+  
+  override func tearDown() {
+  }
+}
+
+extension AppDelegateTests {
+  //supportedInterfaceOrientationsForTopViewController(window: )のテスト
+  //グラフページ（左横向き）のテスト
+  func testGraphPage() {
+    graphNavigationController.viewControllers = [graphViewController]
+    tabBarController.viewControllers = [graphNavigationController]
+    window.rootViewController = tabBarController
+    
+    let result = appDelegate.supportedInterfaceOrientationsForTopViewController(window: window)
+    XCTAssertEqual(result, .landscapeLeft)
+  }
+  //トップページ（縦向き）のテスト
+  func testTopPage() {
+    topNavigationController.viewControllers = [topViewController]
+    tabBarController.viewControllers = [topNavigationController]
+    window.rootViewController = tabBarController
+    
+    let result = appDelegate.supportedInterfaceOrientationsForTopViewController(window: window)
+    XCTAssertEqual(result, .portrait)
+  }
+  
+  //設定ページ（縦向き)のテスト
+  func testSettingsPage() {
+    settingsNavigationController.viewControllers = [settingsViewController]
+    tabBarController.viewControllers = [settingsNavigationController]
+    window.rootViewController = tabBarController
+    
+    let result = appDelegate.supportedInterfaceOrientationsForTopViewController(window: window)
+    XCTAssertEqual(result, .portrait)
+  }
+  
+}

--- a/DietAppTests/GraphPageTests/GraphNavigationControllerTests.swift
+++ b/DietAppTests/GraphPageTests/GraphNavigationControllerTests.swift
@@ -1,0 +1,36 @@
+//
+//  GraphNavigationControllerTests.swift
+//  DietAppTests
+//
+//  Created by 川島真之 on 2024/09/27.
+//
+
+import XCTest
+@testable import DietApp
+
+final class GraphNavigationControllerTests: XCTestCase {
+  
+  var graphNavigationController: GraphNavigationController!
+  
+  override  func setUp() {
+    super.setUp()
+    self.graphNavigationController = GraphNavigationController()
+  }
+  
+  override func tearDown() {
+    graphNavigationController = nil
+    super.tearDown()
+  }
+  
+  
+  override func setUpWithError() throws {
+    // Put setup code here. This method is called before the invocation of each test method in the class.
+  }
+  
+  override func tearDownWithError() throws {
+    // Put teardown code here. This method is called after the invocation of each test method in the class.
+  }
+}
+
+
+


### PR DESCRIPTION
## issue
close #78 

## やったこと
アプリ全体の画面の向きを制御するsupportedInterfaceOrientationsForTopViewControllerメソッドのテスト行った。

## やらなかったこと
Graphページの画面回転を行うgraphViewControllersRotateメソッドのテストは行わなかった。

このメソッドを単体テストするべきか判断ができず、テスト方法も見つけることができなかったので一旦保留する。
supportedInterfaceOrientationsForTopViewControllerもUIに関することなのでUIテストして行うべきかどうか判断がつかないが、こちらは単体テストの方法が見つかったのでテストした。

## 反省
テストに関してさらに調査が必要だと感じた。各メソッドについてそれらをどのようなテストで行うか、そもそもテストの必要があるかを判断がまだできない。
