### PR TITLE
写真の表示形式をAspect Fillに変更した。

### DIFF
--- a/DietApp/View/TopPage/Cell/PhotoTableViewCell.xib
+++ b/DietApp/View/TopPage/Cell/PhotoTableViewCell.xib
@@ -17,7 +17,7 @@
                 <rect key="frame" x="0.0" y="0.0" width="320" height="400"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="rrK-eD-DU2">
+                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="rrK-eD-DU2">
                         <rect key="frame" x="0.0" y="1.5" width="320" height="397"/>
                     </imageView>
                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ytx-di-uC3">


### PR DESCRIPTION
## issue
close #82

## 変更内容
トップ画面の写真の表示形式をAspect Fillに変更した。

## 今後について
Aspect Fillに変更したことで写真全体が表示されなくなったので、何らかの方法で写真全体が確認できるようにしたい。
今の所、写真をダブルタップでモーダルを出しそこに写真全体を表示するよう検討している。