### PR TITLE
モーダル表示の処理を実装

### DIFF
--- a/DietApp/TopPage/PhotoModalViewController.swift
+++ b/DietApp/TopPage/PhotoModalViewController.swift
@@ -8,6 +8,8 @@
 import UIKit
 
 class PhotoModalViewController: UIViewController {
+  
+  var photoModalView = PhotoModalView()
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -15,6 +17,9 @@ class PhotoModalViewController: UIViewController {
         // Do any additional setup after loading the view.
     }
     
+  override func loadView() {
+    view = photoModalView
+  }
 
     /*
     // MARK: - Navigation

--- a/DietApp/TopPage/TopViewController.swift
+++ b/DietApp/TopPage/TopViewController.swift
@@ -234,6 +234,16 @@ extension TopViewController: PhotoTableViewCellDelegate, UIImagePickerController
   func insertButtonAction() {
     showPhotoSelectionActionSheet()
   }
+  //写真がダブルタップされた時の処理
+  func photoDoubleTapAction() {
+    showPhotoModal()
+  }
+  //モーダル表示するメソッド
+  func showPhotoModal() {
+    let photoModalVC = PhotoModalViewController()
+    photoModalVC.modalPresentationStyle = .fullScreen
+    present(photoModalVC, animated: true)
+  }
   //カメラ及びフォトライブラリでキャンセルしたときのデリゲートメソッド
   func imagePickerControllerDidCancel(_ picker: UIImagePickerController) {
     picker.dismiss(animated: true, completion: nil)

--- a/DietApp/View/TopPage/Cell/PhotoTableViewCell.swift
+++ b/DietApp/View/TopPage/Cell/PhotoTableViewCell.swift
@@ -9,10 +9,11 @@ import UIKit
 
 protocol PhotoTableViewCellDelegate {
   func insertButtonAction()
+  func photoDoubleTapAction()
 }
 
 class PhotoTableViewCell: UITableViewCell {
-
+  
   @IBOutlet weak var photoImageView: UIImageView!
   @IBOutlet weak var insertButton: UIButton!
   
@@ -30,6 +31,7 @@ class PhotoTableViewCell: UITableViewCell {
     insertButton.setImage(image, for: .normal)
     
     insertButton.imageView?.contentMode = .scaleAspectFit
+    
     //ボタンのサイズ調整
     if let image = image {
       let buttonSize = CGSize(width: image.size.width + 20, height: image.size.height + 20)
@@ -37,18 +39,39 @@ class PhotoTableViewCell: UITableViewCell {
     }else{
       return
     }
-  }
-
-    override func setSelected(_ selected: Bool, animated: Bool) {
-        super.setSelected(selected, animated: animated)
-        // Configure the view for the selected state
-    }
     
+    setupPhotoDoubleTapGesture()
+  }
+  //写真がダブルタップを感知できるようにする処理
+  func setupPhotoDoubleTapGesture() {
+    // ダブルタップジェスチャーの作成
+    let doubleTapGesture = UITapGestureRecognizer(target: self, action: #selector(photoDoubleTapAction))
+    // タップ回数を2回に設定
+    doubleTapGesture.numberOfTapsRequired = 2
+    
+    // ImageViewのユーザーインタラクションを有効化
+    photoImageView.isUserInteractionEnabled = true
+    // ジェスチャーをImageViewに追加
+    photoImageView.addGestureRecognizer(doubleTapGesture)
+  }
+  
+  
+  override func setSelected(_ selected: Bool, animated: Bool) {
+    super.setSelected(selected, animated: animated)
+    // Configure the view for the selected state
+  }
+  
   @IBAction func insertButtonAction(_ sender: Any) {
     delegate?.insertButtonAction()
   }
   
   @IBAction func redoButtonAction(_ sender: Any) {
     delegate?.insertButtonAction()
+  }
+  
+  @objc func  photoDoubleTapAction() {
+    if photoImageView.image != nil  {
+      delegate?.photoDoubleTapAction()
+    }
   }
 }


### PR DESCRIPTION
## issue
close #86 

## 内容
<img width="306" alt="スクリーンショット 2024-10-18 17 11 33" src="https://github.com/user-attachments/assets/12dec743-8140-4c7e-9f62-84d876da7bbf">

画像はモーダル表示後のもの。モーダルのスタイルはfullScreen。

写真セル内に写真がセットされており、その写真がダブルタップされた時にモーダルを表示するようにした。
写真の表示やモーダルを閉じる処理は実装していない