### PR TITLE
モーダル内の写真表示位置のバグ修正完了

### DIFF
--- a/DietApp/TopPage/PhotoModalViewController.swift
+++ b/DietApp/TopPage/PhotoModalViewController.swift
@@ -23,17 +23,25 @@ class PhotoModalViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
       
+      
       photoModalView.delegate = self
       photoModalView.scrollView.delegate = self
       setScrollView()
         // Do any additional setup after loading the view.
     }
-    
+  
   override func loadView() {
     view = photoModalView
   }
 
-
+  override func viewDidLayoutSubviews() {
+    super.viewDidLayoutSubviews()
+  }
+  
+  override func viewWillAppear(_ animated: Bool) {
+    super.viewWillAppear(animated)
+    centerScrollview()
+  }
     /*
     // MARK: - Navigation
 
@@ -59,12 +67,24 @@ extension PhotoModalViewController: UIScrollViewDelegate {
     //scrollの範囲の設定
     photoModalView.scrollView.minimumZoomScale = 1.0
     photoModalView.scrollView.maximumZoomScale = 4.0
-    //scrollをオフにする
-    photoModalView.scrollView.isScrollEnabled = false
     
+    photoModalView.scrollView.isScrollEnabled = true
+  }
+  //スクロールの初期位置をViewControllerの中心にする設定
+  func centerScrollview() {
+    DispatchQueue.main.async {
+      // コンテンツの中心点を計算
+      let centerX = (self.photoModalView.scrollView.contentSize.width - self.photoModalView.scrollView.bounds.width) / 2
+      let centerY = (self.photoModalView.scrollView.contentSize.height - self.photoModalView.scrollView.bounds.height) / 2
+      
+      // スクロールビューの中心にスクロール
+      let centerPoint = CGPoint(x: centerX, y: centerY)
+      self.photoModalView.scrollView.setContentOffset(centerPoint, animated: false)
+    }
   }
   //スクロール対象の設定
   func viewForZooming(in scrollView: UIScrollView) -> UIView? {
     return photoModalView.photoImageView
   }
+
 }


### PR DESCRIPTION
## issue
close #92 
## 内容
トップページの写真表示用のモーダルを表示した時に、そこの表示されている写真が中心よりやや下に表示されているバグに対応した。
## 修正前後の比較
修正前
<img width="316" alt="スクリーンショット 2024-10-22 13 22 54" src="https://github.com/user-attachments/assets/42c222ed-1a36-4fc9-8ced-e4a2d5e6304f">

修正後
<img width="321" alt="スクリーンショット 2024-10-22 13 23 28" src="https://github.com/user-attachments/assets/baff0fa0-3176-4f19-96a0-8a3d55bbae3e">

## 作業内容
紆余曲折あったので方針、作業の流れを書く。

**1. 余白やAutoLayout周りをチェックした。**
最初はscrollViewの余白等が影響している可能性を考えたので、以下のコードを試用した。
```scrollView.contentInset = .zero```
が、なにも変わらなかったのでAutoLayoutの設定もチェックしてみたが問題点を見つけることができなかった。
**2. ピンチ操作の実装をpinchGestureRecognizerで行おうとした。**
上記のscrollViewでのバグを修正できなかったので、ピンチ操作の実装をpinchGestureRecognizerに乗り換えてみることにした。そもそもscrollViewはピンチ操作の実装の為だけに実装したものだったので、ピンチ操作だけのクラスを使ってみることにした。

PhotoModalViewController.swift
```
override func viewDidLoad() {
        super.viewDidLoad()
        setupPinchGesture()
    }

private func setupPinchGesture() {
        let pinchGesture = UIPinchGestureRecognizer(target: self, action: #selector(handlePinch(_:)))
        imageView.addGestureRecognizer(pinchGesture)
    }

@objc private func handlePinch(_ gesture: UIPinchGestureRecognizer) {
        if gesture.state == .began {
            gesture.view?.transform = gesture.view?.transform ?? .identity
        } else if gesture.state == .changed {

            guard let view = gesture.view else { return }
          
            let minScale: CGFloat = 1.0
            let maxScale: CGFloat = 3.0
            
            var scale = gesture.scale
           
            let currentScale = view.transform.a 
            scale = min(scale, maxScale / currentScale)
            scale = max(scale, minScale / currentScale)
           
            view.transform = view.transform.scaledBy(x: scale, y: scale)

            gesture.scale = 1.0
        }
    }
```
概ね以上のように実装したが、今度は以下の課題が発生した。

- ピンチ操作が定点でしかできない。
- バウンスアニメーションが実装できていない。

これらは追加のコードで実装できる可能性はあったが、内容が煩雑で時間がかかりそうだったので一旦保留し、別の手段にて当初の問題を修正できないか考えた。

**3.scrollViewの初期のスクロール位置をモーダルの中心にした。**
pinchGestureRecognizerへの乗り換えを中止し、scrollViewへ戻ることにした。そこで、初期スクロールの位置をモーダルの中心にすれば、モーダル表示時に画像が画面中央に表示されるのではないかと考えた。

PhotoModalViewController.swift
```
override func viewWillAppear(_ animated: Bool) {
    super.viewWillAppear(animated)
    centerScrollview()
  }

func centerScrollview() {
    DispatchQueue.main.async {
      // コンテンツの中心点を計算
      let centerX = (self.photoModalView.scrollView.contentSize.width - self.photoModalView.scrollView.bounds.width) / 2
      let centerY = (self.photoModalView.scrollView.contentSize.height - self.photoModalView.scrollView.bounds.height) / 2
      
      // スクロールビューの中心にスクロール
      let centerPoint = CGPoint(x: centerX, y: centerY)
      self.photoModalView.scrollView.setContentOffset(centerPoint, animated: false)
    }
  }
```
上記の実装を行ったところ、モーダル表示時に画像が画面中央に表示された。