### PR TITLE
UIに関する幾つかの調整を行った。

### DIFF
--- a/DietApp/TopPage/TopViewController.swift
+++ b/DietApp/TopPage/TopViewController.swift
@@ -150,7 +150,7 @@ extension TopViewController: UITableViewDelegate,UITableViewDataSource {
       cell.selectionStyle = UITableViewCell.SelectionStyle.none
       //写真セルのデリゲート
       cell.delegate = self
-      
+            
       let dateDataRealmSearcher = DateDataRealmSearcher()
       let results = dateDataRealmSearcher.searchForDateDataInRealm(currentDate: topDateManager.date)
       let resultsCount = results.count
@@ -173,6 +173,8 @@ extension TopViewController: UITableViewDelegate,UITableViewDataSource {
           //挿入ボタンとコメントラベルを非表示
           cell.insertButton.isHidden = true
           cell.commentLabel.isHidden = true
+          //やり直しボタンの非表示を解除
+          cell.redoButton.isHidden = false
         }
       }
       return cell
@@ -303,6 +305,8 @@ extension TopViewController: PhotoTableViewCellDelegate, UIImagePickerController
       //ボタンとコメントラベルを非表示にする
       photoTableViewCell.insertButton.isHidden = true
       photoTableViewCell.commentLabel.isHidden = true
+      //やり直しボタンを解除する
+      photoTableViewCell.redoButton.isHidden = false
       //取得したインスタンスのimageに選択した写真を格納
       photoTableViewCell.photoImageView.image = pickedImage
     }

--- a/DietApp/TopPage/TopViewController.swift
+++ b/DietApp/TopPage/TopViewController.swift
@@ -242,6 +242,7 @@ extension TopViewController: PhotoTableViewCellDelegate, UIImagePickerController
   func showPhotoModal(photoImage: UIImage) {
     let storyboard = UIStoryboard(name: "Main", bundle: nil)
     if let photoModalVC = storyboard.instantiateViewController(withIdentifier: "PhotoModalVC") as? PhotoModalViewController {
+      photoModalVC.modalPresentationStyle = .fullScreen
       photoModalVC.photoModalView.photoImageView.image = photoImage
       self.present(photoModalVC, animated: true, completion: nil)
     }

--- a/DietApp/View/TopPage/Cell/PhotoTableViewCell.swift
+++ b/DietApp/View/TopPage/Cell/PhotoTableViewCell.swift
@@ -19,6 +19,7 @@ class PhotoTableViewCell: UITableViewCell {
   
   @IBOutlet weak var commentLabel: UILabel!
   @IBOutlet weak var redoButton: UIButton!
+  var isRedoButtonConfigured = false
   
   var delegate: PhotoTableViewCellDelegate?
   
@@ -39,6 +40,7 @@ class PhotoTableViewCell: UITableViewCell {
     insertButton.setImage(image, for: .normal)
     
     insertButton.imageView?.contentMode = .scaleAspectFit
+    redoButton.isHidden = true
     
     //ボタンのサイズ調整
     if let image = image {
@@ -47,9 +49,42 @@ class PhotoTableViewCell: UITableViewCell {
     }else{
       return
     }
-    
     setupPhotoDoubleTapGesture()
   }
+
+  override func layoutSubviews() {
+    super.layoutSubviews()
+    if !isRedoButtonConfigured {
+      setRedoButtonCornerRadius()
+      applyFrostedGlassEffect()
+      isRedoButtonConfigured = true
+    }
+  }
+  //やり直しボタンを丸くするメソッド
+  func setRedoButtonCornerRadius() {
+    redoButton.layer.cornerRadius = redoButton.frame.size.width / 2
+    redoButton.clipsToBounds = true
+  }
+  
+  private func applyFrostedGlassEffect() {
+    // ぼかし効果を持つビューを作成
+    let frostedEffect = UIVisualEffectView(effect: UIBlurEffect(style: .light))
+    frostedEffect.frame = redoButton.bounds
+    frostedEffect.layer.cornerRadius = redoButton.frame.size.width / 2
+    frostedEffect.clipsToBounds = true
+    
+    // ぼかし効果のユーザーインタラクションを無効にする
+    //これをしないとボタンをタップしても反応しなくなる
+    //すりガラス効果がボタンの上に乗っかるのでタップイベントがボタンに届かなくなため
+    frostedEffect.isUserInteractionEnabled = false
+    // UIButtonの背景をクリアに設定
+    redoButton.backgroundColor = .clear
+    // ぼかし効果の背景色を設定（透明度を調整）
+    frostedEffect.alpha = 0.5
+    // ぼかし効果をボタンの上に追加
+    redoButton.insertSubview(frostedEffect, at: 0)
+  }
+  
   //写真がダブルタップを感知できるようにする処理
   func setupPhotoDoubleTapGesture() {
     // ダブルタップジェスチャーの作成
@@ -62,6 +97,8 @@ class PhotoTableViewCell: UITableViewCell {
     // ジェスチャーをImageViewに追加
     photoImageView.addGestureRecognizer(doubleTapGesture)
   }
+  
+  
   
   
   override func setSelected(_ selected: Bool, animated: Bool) {

--- a/DietApp/View/TopPage/Cell/PhotoTableViewCell.xib
+++ b/DietApp/View/TopPage/Cell/PhotoTableViewCell.xib
@@ -5,6 +5,7 @@
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23084"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -19,6 +20,7 @@
                 <subviews>
                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="rrK-eD-DU2">
                         <rect key="frame" x="0.0" y="1.5" width="320" height="397"/>
+                        <color key="backgroundColor" systemColor="systemGray6Color"/>
                     </imageView>
                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ytx-di-uC3">
                         <rect key="frame" x="276" y="346" width="44" height="44"/>
@@ -74,5 +76,8 @@
     <resources>
         <image name="arrow.trianglehead.counterclockwise" catalog="system" width="119" height="128"/>
         <image name="camera" catalog="system" width="128" height="93"/>
+        <systemColor name="systemGray6Color">
+            <color red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
     </resources>
 </document>

--- a/DietApp/View/TopPage/PhotoModalView.swift
+++ b/DietApp/View/TopPage/PhotoModalView.swift
@@ -17,6 +17,7 @@ class PhotoModalView: UIView {
   @IBOutlet weak var scrollView: UIScrollView!
   @IBOutlet weak var photoImageView: UIImageView!
   @IBOutlet weak var dismissButton: UIButton!
+  var  isDismissButtonConfigured = false
   
   var delegate: PhotoModalViewDelegate?
   
@@ -37,6 +38,16 @@ class PhotoModalView: UIView {
     dismissButton.setImage(image, for: .normal)
   }
   
+  override func layoutSubviews() {
+    super.layoutSubviews()
+    if !isDismissButtonConfigured {
+      setDismissButtonCornerRadius()
+      applyFrostedGlassEffect()
+      isDismissButtonConfigured = true
+    }
+  }
+  
+  
   func nibInit(){
     //xibファイルのインスタンス作成
     let nib = UINib(nibName: "PhotoModalView", bundle: nil)
@@ -51,6 +62,30 @@ class PhotoModalView: UIView {
   
   @IBAction func dismissButtonAction(_ sender: Any) {
     delegate?.dismiss()
+  }
+  
+  func setDismissButtonCornerRadius() {
+    dismissButton.layer.cornerRadius = dismissButton.frame.size.width / 2
+    dismissButton.clipsToBounds = true
+  }
+  
+  private func applyFrostedGlassEffect() {
+    // ぼかし効果を持つビューを作成
+    let frostedEffect = UIVisualEffectView(effect: UIBlurEffect(style: .light))
+    frostedEffect.frame = dismissButton.bounds
+    frostedEffect.layer.cornerRadius = dismissButton.frame.size.width / 2
+    frostedEffect.clipsToBounds = true
+    
+    // ぼかし効果のユーザーインタラクションを無効にする
+    //これをしないとボタンをタップしても反応しなくなる
+    //すりガラス効果がボタンの上に乗っかるのでタップイベントがボタンに届かなくなため
+    frostedEffect.isUserInteractionEnabled = false
+    // UIButtonの背景をクリアに設定
+    dismissButton.backgroundColor = .clear
+    // ぼかし効果の背景色を設定（透明度を調整）
+    frostedEffect.alpha = 0.5
+    // ぼかし効果をボタンの上に追加
+    dismissButton.insertSubview(frostedEffect, at: 0)
   }
   
   

--- a/DietApp/View/TopPage/PhotoModalView.xib
+++ b/DietApp/View/TopPage/PhotoModalView.xib
@@ -32,7 +32,11 @@
                             </constraints>
                         </imageView>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="UVP-5S-keN">
-                            <rect key="frame" x="338.66666666666669" y="8" width="46.333333333333314" height="34.333333333333336"/>
+                            <rect key="frame" x="341" y="8" width="44" height="44"/>
+                            <constraints>
+                                <constraint firstAttribute="height" constant="44" id="5Su-13-nUD"/>
+                                <constraint firstAttribute="width" constant="44" id="ObK-1O-oFz"/>
+                            </constraints>
                             <state key="normal" title="Button" backgroundImage="xmark" catalog="system"/>
                             <buttonConfiguration key="configuration" style="plain" image="xmark" catalog="system"/>
                             <connections>
@@ -42,11 +46,11 @@
                     </subviews>
                     <constraints>
                         <constraint firstItem="8Su-Bx-U2C" firstAttribute="width" secondItem="vlA-6u-66v" secondAttribute="width" id="52R-pk-nku"/>
-                        <constraint firstItem="GZY-Ur-kBV" firstAttribute="trailing" secondItem="UVP-5S-keN" secondAttribute="trailing" constant="8" id="A80-rM-fIO"/>
+                        <constraint firstItem="UVP-5S-keN" firstAttribute="top" secondItem="GZY-Ur-kBV" secondAttribute="top" constant="8" id="6av-2U-rb4"/>
                         <constraint firstAttribute="bottom" secondItem="8Su-Bx-U2C" secondAttribute="bottom" id="B2U-qm-erP"/>
-                        <constraint firstItem="UVP-5S-keN" firstAttribute="top" secondItem="GZY-Ur-kBV" secondAttribute="top" constant="8" id="CTb-bI-C62"/>
                         <constraint firstAttribute="trailing" secondItem="8Su-Bx-U2C" secondAttribute="trailing" id="I0F-IQ-0OQ"/>
                         <constraint firstItem="8Su-Bx-U2C" firstAttribute="top" secondItem="vlA-6u-66v" secondAttribute="top" id="KZg-ss-nMG"/>
+                        <constraint firstItem="GZY-Ur-kBV" firstAttribute="trailing" secondItem="UVP-5S-keN" secondAttribute="trailing" constant="8" id="m9m-NL-wnc"/>
                         <constraint firstItem="8Su-Bx-U2C" firstAttribute="leading" secondItem="vlA-6u-66v" secondAttribute="leading" id="p7g-q3-uZQ"/>
                     </constraints>
                     <viewLayoutGuide key="contentLayoutGuide" id="scy-7Q-hgh"/>


### PR DESCRIPTION
## issue
close #96 

## 作業内容

- **写真セルの背景色を薄灰色に変更**
- **写真セルに写真がセットされていない時に撮り直しのボタンを非表示にするようにした**
<img width="314" alt="スクリーンショット 2024-10-28 0 05 40" src="https://github.com/user-attachments/assets/306873a9-14d9-4fb6-b018-c38ea693499d">

- **写真モーダルの表示形式をfullscreenに変更**
- **モーダルを閉じるボタンと撮り直しボタンの形を円形に変更し、ボタンの背景にすりガラスのエフェクトを追加した**
<img width="310" alt="スクリーンショット 2024-10-28 0 08 09" src="https://github.com/user-attachments/assets/de76e54e-48b0-4c02-83f1-9d3a1f7b88f2">
<img width="310" alt="スクリーンショット 2024-10-28 0 13 23" src="https://github.com/user-attachments/assets/cae2ac7a-7b47-476d-860a-39481db88f0a">