### PR TITLE
エラーログへの対処をした

### DIFF
--- a/DietApp.xcodeproj/xcshareddata/xcschemes/DietApp.xcscheme
+++ b/DietApp.xcodeproj/xcshareddata/xcschemes/DietApp.xcscheme
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1600"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FA68AF1C2A135F6F00B69D4A"
+               BuildableName = "DietApp.app"
+               BlueprintName = "DietApp"
+               ReferencedContainer = "container:DietApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FA68AF322A135F7200B69D4A"
+               BuildableName = "DietAppTests.xctest"
+               BlueprintName = "DietAppTests"
+               ReferencedContainer = "container:DietApp.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FA68AF3C2A135F7200B69D4A"
+               BuildableName = "DietAppUITests.xctest"
+               BlueprintName = "DietAppUITests"
+               ReferencedContainer = "container:DietApp.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "FA68AF1C2A135F6F00B69D4A"
+            BuildableName = "DietApp.app"
+            BlueprintName = "DietApp"
+            ReferencedContainer = "container:DietApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "CG_CONTEXT_SHOW_BACKTRACE"
+            value = "CG_CONTEXT_SHOW_BACKTRACE"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "FA68AF1C2A135F6F00B69D4A"
+            BuildableName = "DietApp.app"
+            BlueprintName = "DietApp"
+            ReferencedContainer = "container:DietApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/DietApp.xcodeproj/xcuserdata/kawashimamasayuki.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/DietApp.xcodeproj/xcuserdata/kawashimamasayuki.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -10,5 +10,23 @@
 			<integer>9</integer>
 		</dict>
 	</dict>
+	<key>SuppressBuildableAutocreation</key>
+	<dict>
+		<key>FA68AF1C2A135F6F00B69D4A</key>
+		<dict>
+			<key>primary</key>
+			<true/>
+		</dict>
+		<key>FA68AF322A135F7200B69D4A</key>
+		<dict>
+			<key>primary</key>
+			<true/>
+		</dict>
+		<key>FA68AF3C2A135F7200B69D4A</key>
+		<dict>
+			<key>primary</key>
+			<true/>
+		</dict>
+	</dict>
 </dict>
 </plist>

--- a/DietApp/View/TopPage/Cell/PhotoTableViewCell.swift
+++ b/DietApp/View/TopPage/Cell/PhotoTableViewCell.swift
@@ -16,23 +16,14 @@ class PhotoTableViewCell: UITableViewCell {
   
   @IBOutlet weak var photoImageView: UIImageView!
   @IBOutlet weak var insertButton: UIButton!
-  
   @IBOutlet weak var commentLabel: UILabel!
   @IBOutlet weak var redoButton: UIButton!
-  var isRedoButtonConfigured = false
   
+  var isRedoButtonConfigured = false
   var delegate: PhotoTableViewCellDelegate?
   
   override func awakeFromNib() {
     super.awakeFromNib()
-    
-    //redoButtonのイメージ設定
-    //iOS18以降かどうかでイメージを変える
-    if #available(iOS 18.0, *) {
-      redoButton.setImage(UIImage(systemName: "arrow.trianglehead.counterclockwise"), for: .normal)
-    } else {
-      redoButton.setImage(UIImage(systemName: "gobackward"), for: .normal)
-    }
     
     //systemImageのサイズ調整
     let symbolConfiguration = UIImage.SymbolConfiguration(pointSize: 40)
@@ -97,8 +88,6 @@ class PhotoTableViewCell: UITableViewCell {
     // ジェスチャーをImageViewに追加
     photoImageView.addGestureRecognizer(doubleTapGesture)
   }
-  
-  
   
   
   override func setSelected(_ selected: Bool, animated: Bool) {

--- a/DietApp/View/TopPage/Cell/PhotoTableViewCell.xib
+++ b/DietApp/View/TopPage/Cell/PhotoTableViewCell.xib
@@ -29,7 +29,7 @@
                             <constraint firstAttribute="height" constant="44" id="Jje-GH-GcB"/>
                         </constraints>
                         <state key="normal" title="Button"/>
-                        <buttonConfiguration key="configuration" style="plain" image="arrow.trianglehead.counterclockwise" catalog="system"/>
+                        <buttonConfiguration key="configuration" style="plain" image="arrowshape.turn.up.left.fill" catalog="system"/>
                         <connections>
                             <action selector="redoButtonAction:" destination="KGk-i7-Jjw" eventType="touchUpInside" id="DYG-m8-sI3"/>
                         </connections>
@@ -46,7 +46,7 @@
                         <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
                         <state key="normal" image="camera" catalog="system"/>
                         <connections>
-                            <action selector="insertButtonAction:" destination="KGk-i7-Jjw" eventType="touchUpInside" id="3op-f5-0EV"/>
+                            <action selector="insertButtonAction:" destination="KGk-i7-Jjw" eventType="touchUpInside" id="UlB-ga-9NP"/>
                         </connections>
                     </button>
                 </subviews>
@@ -66,7 +66,7 @@
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
             <connections>
                 <outlet property="commentLabel" destination="DL6-uU-7i8" id="V1u-rp-Xsb"/>
-                <outlet property="insertButton" destination="oKB-hh-oFN" id="YXj-eT-eVf"/>
+                <outlet property="insertButton" destination="oKB-hh-oFN" id="qZw-f3-LUi"/>
                 <outlet property="photoImageView" destination="rrK-eD-DU2" id="Utg-w1-725"/>
                 <outlet property="redoButton" destination="Ytx-di-uC3" id="GO2-68-B6c"/>
             </connections>
@@ -74,7 +74,7 @@
         </tableViewCell>
     </objects>
     <resources>
-        <image name="arrow.trianglehead.counterclockwise" catalog="system" width="119" height="128"/>
+        <image name="arrowshape.turn.up.left.fill" catalog="system" width="128" height="104"/>
         <image name="camera" catalog="system" width="128" height="93"/>
         <systemColor name="systemGray6Color">
             <color red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>


### PR DESCRIPTION
## issue
close #98 

## エラーログ
CGBitmapContextCreateImage: invalid context 0x0. If you want to see the backtrace, please set CG_CONTEXT_SHOW_BACKTRACE environmental variable.

## 対処内容
エラーログの内容がredoボタンのイメージによるものだったので、redoボタンのイメージarrow.trianglehead.counterclockwiseからarrowshape.turn.up.left.fillに変更した。
<img width="322" alt="スクリーンショット 2024-10-29 0 07 27" src="https://github.com/user-attachments/assets/4b32657c-b82b-453c-ae93-62841005b803">

## 対処の流れ
1. まずログメッセージで検索したところ、エラーのバックトレースを表示する方法を紹介している以下の記事を見つけたのでその通りにやってみた。
[https://qiita.com/john-rocky/items/7dfe0179b9ebe9b96512](url)
2. 次にバックトレースの内容をclaudeに照会させたところ、PhotoTableViewCell内のボタンの初期化時に問題が出ていると回答された。
3. redoボタンのイメージ（SFSymbols）を直近の作業で構っていたためここが怪しい思い、別のイメージに変えたらログが発生しなくなった。
redoボタンのイメージはarrow.trianglehead.counterclockwiseを使っていたが、このイメージはiOS18以降でしか使えないためコードでフォローバックイメージとの切り替えの処理を行なっていたが、おそらくコードではなくAssetCatlogにフォローバックイメージを追加しないとこのエラーログがでると仮定した。
4. そこでAssetCatlogへフォローバックイメージを追加する方法を調査したが情報が少なくこの方法を実現できなかった。
5. なのでひとまずiOSのverに制約を受けないSFSymbolsのイメージ（arrowshape.turn.up.left.fill）で代用することにした。

## 今後について
AssetCatlogへフォローバックイメージを追加するというのは基本的な作業に思えるので情報が少ないことにすこし驚いた。もしかしたら調べ方が悪かったかもしれないので、方法が判明しだい元のイメージに戻したい。