### PR TITLE
エラーログへの対処と他作業の完了

### DIFF
--- a/DietApp.xcodeproj/project.pbxproj
+++ b/DietApp.xcodeproj/project.pbxproj
@@ -926,6 +926,7 @@
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UIMainStoryboardFile = Main;
+				INFOPLIST_KEY_UIRequiresFullScreen = YES;
 				INFOPLIST_KEY_UIStatusBarStyle = "";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationPortrait";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -957,6 +958,7 @@
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UIMainStoryboardFile = Main;
+				INFOPLIST_KEY_UIRequiresFullScreen = YES;
 				INFOPLIST_KEY_UIStatusBarStyle = "";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationPortrait";
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/DietApp/TopPage/TopViewController.swift
+++ b/DietApp/TopPage/TopViewController.swift
@@ -118,6 +118,7 @@ extension TopViewController: UITableViewDelegate,UITableViewDataSource {
       //セルの選択時のハイライトを非表示にする
       cell.selectionStyle = UITableViewCell.SelectionStyle.none
       cell.weightTextField.delegate = self
+      cell.delegate = self
       
       let dateDataRealmSearcher = DateDataRealmSearcher()
       let results = dateDataRealmSearcher.searchForDateDataInRealm(currentDate: topDateManager.date)
@@ -224,7 +225,11 @@ extension TopViewController: UITableViewDelegate,UITableViewDataSource {
 }
 //UITextField周りの処理
 //エンターを押したらキーボードを閉じる処理
-extension TopViewController {
+extension TopViewController: WeightTableViewCellDelegate {
+  func weightTableViewCellDidRequestKeyboardDismiss(_ cell: WeightTableViewCell) {
+    view.endEditing(true)
+  }
+  
   //キーボード以外の領域をタッチしたらキーボードを閉じる処理
   @objc public func dismissKeyboard() {
     view.endEditing(true)

--- a/DietApp/View/TopPage/Cell/MemoTableViewCell.swift
+++ b/DietApp/View/TopPage/Cell/MemoTableViewCell.swift
@@ -14,10 +14,10 @@ class MemoTableViewCell: UITableViewCell {
   override func awakeFromNib() {
         super.awakeFromNib()
         // Initialization code
-    
+    memoTextField.keyboardType = .default
+    memoTextField.returnKeyType = .done
     memoTextField.delegate = self
     memoTextField.autocorrectionType = .no
-    
     
     let placeholderText = "ひとことメモ"
     let attributes = [
@@ -26,7 +26,6 @@ class MemoTableViewCell: UITableViewCell {
     memoTextField.attributedPlaceholder = NSAttributedString(string: placeholderText, attributes: attributes)
     }
   
-    
 
     override func setSelected(_ selected: Bool, animated: Bool) {
         super.setSelected(selected, animated: animated)

--- a/DietApp/View/TopPage/Cell/WeightTableViewCell.swift
+++ b/DietApp/View/TopPage/Cell/WeightTableViewCell.swift
@@ -7,10 +7,16 @@
 
 import UIKit
 
+protocol WeightTableViewCellDelegate: AnyObject {
+    func weightTableViewCellDidRequestKeyboardDismiss(_ cell: WeightTableViewCell)
+}
+
 class WeightTableViewCell: UITableViewCell {
   
   @IBOutlet weak var weightTextField: UITextField!
   @IBOutlet weak var kgLabel: UILabel!
+  
+  var delegate: WeightTableViewCellDelegate?
   
   override func awakeFromNib() {
     super.awakeFromNib()
@@ -46,21 +52,18 @@ class WeightTableViewCell: UITableViewCell {
 //キーボード上部の閉じるボタンを作成
 extension WeightTableViewCell {
   func setUpCloseButton() {
-    let toolBar = UIToolbar()
-    toolBar.sizeToFit()
-    //単に新しいTopViewControllerのインスタンスを作るだけで良いのか、現在の最上位のビュー（TopViewContoller)を取得した方が良いのか後日確認
-    let topVC = TopViewController()
-    // スペーサー構築
-    let spacer = UIBarButtonItem(barButtonSystemItem: UIBarButtonItem.SystemItem.flexibleSpace, target: self, action: nil)
-    // 閉じるボタン構築
-    let closeButton = UIBarButtonItem(barButtonSystemItem: UIBarButtonItem.SystemItem.close, target: topVC, action:#selector(TopViewController.dismissKeyboard))
+    let toolBar = UIToolbar(frame: CGRect(x: 0, y: 0, width: UIScreen.main.bounds.width, height: 44))
+    let spacer = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
+    // セル自身をターゲットとして、内部メソッド経由でデリゲートを呼び出す
+    let closeButton = UIBarButtonItem(barButtonSystemItem: .close, target: self, action: #selector(handleCloseButtonTap))
     
     toolBar.items = [spacer, closeButton]
     weightTextField.inputAccessoryView = toolBar
-    // MARK: - 閉じるボタン
+  }
+  @objc private func handleCloseButtonTap() {
+    delegate?.weightTableViewCellDidRequestKeyboardDismiss(self)
   }
 }
-
 
 //拡張の内容、記述場所は後日検討
 extension UITextField {


### PR DESCRIPTION
## issue
close #100 

## 作業内容

**1. 体重セルのキーボードのツールバーの制約に関するエラーログの解消**
以下のエラーログを解消。ツールバーのサイズを明示した。

Unable to simultaneously satisfy constraints.
Probably at least one of the constraints in the following list is one you don't want.
Try this:
(1) look at each constraint and try to figure out which you don't expect;
(2) find the code that added the unwanted constraint or constraints and fix it.
(Note: If you're seeing NSAutoresizingMaskLayoutConstraints that you don't understand, refer to the documentation for the UIView property translatesAutoresizingMaskIntoConstraints)
(
"<NSAutoresizingMaskLayoutConstraint:0x30287a800 h=--& v=--& _UIToolbarContentView:0x151d3c060.width == 0 (active)>",
"<NSLayoutConstraint:0x30280ee90 H:|-(0)-[_UIButtonBarStackView:0x151d3e260] (active, names: '|':_UIToolbarContentView:0x151d3c060 )>",
"<NSLayoutConstraint:0x30280eee0 H:[_UIButtonBarStackView:0x151d3e260]-(0)-| (active, names: '|':_UIToolbarContentView:0x151d3c060 )>",
"<NSLayoutConstraint:0x302879d10 'IB_Leading_Leading' H:|-(16)-[_UIModernBarButton:0x151e8e610] (active, names: '|':_UIButtonBarButton:0x151e8e210 )>",
"<NSLayoutConstraint:0x302879d60 'IB_Trailing_Trailing' H:[_UIModernBarButton:0x151e8e610]-(16)-| (active, names: '|':_UIButtonBarButton:0x151e8e210 )>",
"<NSLayoutConstraint:0x30287a350 'UISV-canvas-connection' UILayoutGuide:0x303235420'UIViewLayoutMarginsGuide'.leading == UIView:0x151e8dfb0.leading (active)>",
"<NSLayoutConstraint:0x30287a3a0 'UISV-canvas-connection' UILayoutGuide:0x303235420'UIViewLayoutMarginsGuide'.trailing == _UIButtonBarButton:0x151e8e210.trailing (active)>",
"<NSLayoutConstraint:0x30287a260 'UISV-spacing' H:[UIView:0x151e8dfb0]-(0)-[_UIButtonBarButton:0x151e8e210] (active)>",
"<NSLayoutConstraint:0x30280eda0 'UIView-leftMargin-guide-constraint' H:|-(0)-[[UILayoutGuide:0x303235420'UIViewLayoutMarginsGuide'](https://www.notion.so/LTR)](https://www.notion.so/LTR) (active, names: '|':_UIButtonBarStackView:0x151d3e260 )>",
"<NSLayoutConstraint:0x30280ee40 'UIView-rightMargin-guide-constraint' H:[UILayoutGuide:0x303235420'UIViewLayoutMarginsGuide']-(0)-|(LTR) (active, names: '|':_UIButtonBarStackView:0x151d3e260 )>"
)
Will attempt to recover by breaking constraint
<NSLayoutConstraint:0x302879d60 'IB_Trailing_Trailing' H:[_UIModernBarButton:0x151e8e610]-(16)-| (active, names: '|':_UIButtonBarButton:0x151e8e210 )>

Make a symbolic breakpoint at UIViewAlertForUnsatisfiableConstraints to catch this in the debugger.
The methods in the UIConstraintBasedLayoutDebugging category on UIView listed in <UIKitCore/UIView.h> may also be helpful.

**2. All interface orientations must be supported unless the app requires full screen.への対処**
Targets -> General -> Deployment Info -> Requires full screenにチェックを入れた。

**3. メモセルのキーボードのリターンキーの表示の変更**
改行から完了に変更した
<img width="310" alt="スクリーンショット 2024-10-29 23 04 18" src="https://github.com/user-attachments/assets/1e9138b3-e96b-43b4-97e6-6d43b4b4efeb">

## 対処しなかった内容

**1. 体重セルのキーボードを表示したままメモセルのキーボードを表示した時にでるエラーログ**
調べた限りXCodeのバグらしいので修正されるまで放置する。

Unable to simultaneously satisfy constraints.
Probably at least one of the constraints in the following list is one you don't want.
Try this:
(1) look at each constraint and try to figure out which you don't expect;
(2) find the code that added the unwanted constraint or constraints and fix it.
(
"<NSLayoutConstraint:0x302815810 'accessoryView.bottom' _UIRemoteKeyboardPlaceholderView:0x151e44550.bottom == _UIKBCompatInputView:0x153311380.top (active)>",
"<NSLayoutConstraint:0x30287e3a0 'assistantHeight' SystemInputAssistantView.height == 44 (active, names: SystemInputAssistantView:0x15330a270 )>",
"<NSLayoutConstraint:0x3028780a0 'assistantView.bottom' SystemInputAssistantView.bottom == _UIKBCompatInputView:0x153311380.top (active, names: SystemInputAssistantView:0x15330a270 )>",
"<NSLayoutConstraint:0x302878050 'assistantView.top' V:[_UIRemoteKeyboardPlaceholderView:0x151e44550]-(0)-[SystemInputAssistantView] (active, names: SystemInputAssistantView:0x15330a270 )>"
)

Will attempt to recover by breaking constraint
<NSLayoutConstraint:0x302878050 'assistantView.top' V:[_UIRemoteKeyboardPlaceholderView:0x151e44550]-(0)-[SystemInputAssistantView] (active, names: SystemInputAssistantView:0x15330a270 )>

Make a symbolic breakpoint at UIViewAlertForUnsatisfiableConstraints to catch this in the debugger.
The methods in the UIConstraintBasedLayoutDebugging category on UIView listed in <UIKitCore/UIView.h> may also be helpful.

**2. メモセルのキーボードを表示するとたまに表示されるエラーログ**
これもXCodeのバグらしいので放置。

-[RTIInputSystemClient remoteTextInputSessionWithID:performInputOperation:]  perform input operation requires a valid sessionID. inputModality = Keyboard, inputOperation = <null selector>, customInfoType = UIEmojiSearchOperations
