### PR TITLE
トップのバリデーションエラー時のアラートの表示メソッドを作成した

### DIFF
--- a/DietApp/Model/Logic/TopPageTextFieldValidation/MemoTextFieldValidation.swift
+++ b/DietApp/Model/Logic/TopPageTextFieldValidation/MemoTextFieldValidation.swift
@@ -61,7 +61,7 @@ struct NewLineValidator: MemoValidator {
     return .valid
   }
 }
-
+//validatorをまとめる
 struct MemoInputValidator: CompositeMemoValidator {
   var validators: [MemoValidator]
   

--- a/DietApp/TopPage/TopViewController.swift
+++ b/DietApp/TopPage/TopViewController.swift
@@ -367,6 +367,22 @@ extension TopViewController: UITextFieldDelegate {
     textField.resignFirstResponder()
     return true
   }
+  //バリデーションエラーのアラートを表示する
+  func showValidationErrorAlert(errorText: String) {
+    let alert = UIAlertController(title: "", message: errorText, preferredStyle: .alert)
+    
+    let attributedTitle = NSAttributedString(string: "入力エラー", attributes: [
+      .foregroundColor: UIColor.red,
+      .font: UIFont.boldSystemFont(ofSize: 18) // ボールドフォント
+    ])
+    alert.setValue(attributedTitle, forKey: "attributedTitle")
+    
+    let okAction = UIAlertAction(title: "OK", style: .default) { _ in
+      alert.dismiss(animated: true, completion: nil)
+    }
+    alert.addAction(okAction)
+    self.present(alert, animated: true, completion: nil)
+  }
   
   func textFieldDidEndEditing(_ textField: UITextField) {
     
@@ -378,6 +394,7 @@ extension TopViewController: UITextFieldDelegate {
         print("メモは問題なし")
       case .invalid(let validationError):
         print(validationError.localizedDescription)
+        showValidationErrorAlert(errorText: validationError.localizedDescription)
       }
     }
     


### PR DESCRIPTION
## issue
close #108 

## 内容
トップのバリデーションエラー時のアラートの表示メソッドを作成した。
当初アラートのカスタムクラスを作成しようかと思っていたが、カスタム内容が簡単なものだったのでTopViewControllerのメソッドとして作成した。

## 実装イメージ
メモテキストフィールドの文字数が超過した場合を例として表示する。

<img width="320" alt="スクリーンショット 2024-11-12 10 31 16" src="https://github.com/user-attachments/assets/8a8e75c1-3109-488d-bae0-3b49e9abac5e">
