### PR TITLE
テキストフィールドのペースト時の問題に対処した。

### DIFF
--- a/DietApp.xcodeproj/project.pbxproj
+++ b/DietApp.xcodeproj/project.pbxproj
@@ -12,7 +12,6 @@
 		60A4C6E95A42A5E6FBC4EC82 /* Pods_DietApp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 71B7CEEB90849C4649195C6F /* Pods_DietApp.framework */; };
 		FA0F9ECF2A2F0DEC00C7E888 /* GraphPageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA0F9ECE2A2F0DEC00C7E888 /* GraphPageViewController.swift */; };
 		FA0F9ED12A3016D100C7E888 /* UITabBarController+Orientation.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA0F9ED02A3016D100C7E888 /* UITabBarController+Orientation.swift */; };
-		FA10AD112CDD9A4100AF9404 /* TopTextFieldValidation.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA10AD102CDD9A4100AF9404 /* TopTextFieldValidation.swift */; };
 		FA10AD132CDDC2F900AF9404 /* WeightTextFieldValidation.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA10AD122CDDC2F900AF9404 /* WeightTextFieldValidation.swift */; };
 		FA10AD152CDDC39700AF9404 /* ValidationError + ValidationResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA10AD142CDDC39700AF9404 /* ValidationError + ValidationResult.swift */; };
 		FA10AD1E2CDDDBDF00AF9404 /* WeightTextFieldValidationTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA10AD1D2CDDDBDF00AF9404 /* WeightTextFieldValidationTest.swift */; };
@@ -105,7 +104,6 @@
 		F33E63A5ACE3D0B165D13D9B /* Pods-DietAppTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DietAppTests.debug.xcconfig"; path = "Target Support Files/Pods-DietAppTests/Pods-DietAppTests.debug.xcconfig"; sourceTree = "<group>"; };
 		FA0F9ECE2A2F0DEC00C7E888 /* GraphPageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphPageViewController.swift; sourceTree = "<group>"; };
 		FA0F9ED02A3016D100C7E888 /* UITabBarController+Orientation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITabBarController+Orientation.swift"; sourceTree = "<group>"; };
-		FA10AD102CDD9A4100AF9404 /* TopTextFieldValidation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopTextFieldValidation.swift; sourceTree = "<group>"; };
 		FA10AD122CDDC2F900AF9404 /* WeightTextFieldValidation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeightTextFieldValidation.swift; sourceTree = "<group>"; };
 		FA10AD142CDDC39700AF9404 /* ValidationError + ValidationResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ValidationError + ValidationResult.swift"; sourceTree = "<group>"; };
 		FA10AD1D2CDDDBDF00AF9404 /* WeightTextFieldValidationTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeightTextFieldValidationTest.swift; sourceTree = "<group>"; };
@@ -238,7 +236,6 @@
 			children = (
 				FA10AD142CDDC39700AF9404 /* ValidationError + ValidationResult.swift */,
 				FA10AD122CDDC2F900AF9404 /* WeightTextFieldValidation.swift */,
-				FA10AD102CDD9A4100AF9404 /* TopTextFieldValidation.swift */,
 				FA10AD1F2CDE3B8A00AF9404 /* MemoTextFieldValidation.swift */,
 			);
 			path = TopPageTextFieldValidation;
@@ -377,10 +374,18 @@
 				FA42FA2E2A6B6CB700C60F9E /* DateDataRealmSearcherTests.swift */,
 				FA42FA2C2A6A4C1200C60F9E /* IndexSetterTests.swift */,
 				FA42FA492A7F3BE600C60F9E /* MonthAdjusterTests.swift */,
-				FA10AD1D2CDDDBDF00AF9404 /* WeightTextFieldValidationTest.swift */,
-				FA10AD272CE060A600AF9404 /* MemoTextFieldValidationTest.swift */,
+				FA55F5B42CE58D080015291F /* TopPageTextFieldValidationTest */,
 			);
 			path = ModelTests;
+			sourceTree = "<group>";
+		};
+		FA55F5B42CE58D080015291F /* TopPageTextFieldValidationTest */ = {
+			isa = PBXGroup;
+			children = (
+				FA10AD272CE060A600AF9404 /* MemoTextFieldValidationTest.swift */,
+				FA10AD1D2CDDDBDF00AF9404 /* WeightTextFieldValidationTest.swift */,
+			);
+			path = TopPageTextFieldValidationTest;
 			sourceTree = "<group>";
 		};
 		FA68AF142A135F6F00B69D4A = {
@@ -731,7 +736,6 @@
 				FA24A86F2CA566950082AF19 /* SettingsNavigationController.swift in Sources */,
 				FA41A2EC2A1C84CE008DC83E /* TopViewController.swift in Sources */,
 				FA32F4C82A32C0900058FD32 /* ThemeColorTableViewCell.swift in Sources */,
-				FA10AD112CDD9A4100AF9404 /* TopTextFieldValidation.swift in Sources */,
 				FA3142702A41671900254D60 /* TopNavigationController.swift in Sources */,
 				FA3142742A4194F300254D60 /* GraphNavigationController.swift in Sources */,
 				FA41A2EE2A1C8531008DC83E /* TopPageViewController.swift in Sources */,

--- a/DietApp/TopPage/TopViewController.swift
+++ b/DietApp/TopPage/TopViewController.swift
@@ -374,7 +374,6 @@ extension TopViewController: UITextFieldDelegate {
   }
   
   //テキストフィールドの編集が終了した時
-  //, !text.isEmpty
   func textFieldDidEndEditing(_ textField: UITextField) {
     
     guard let text = textField.text else { return }
@@ -440,6 +439,7 @@ extension TopViewController: UITextFieldDelegate {
       textField.becomeFirstResponder()
       //テキストを空にする
       textField.text = ""
+      
       //アラートを閉じる
       alert.dismiss(animated: true, completion: nil)
     }

--- a/DietApp/View/TopPage/Cell/MemoTableViewCell.swift
+++ b/DietApp/View/TopPage/Cell/MemoTableViewCell.swift
@@ -18,6 +18,10 @@ class MemoTableViewCell: UITableViewCell {
     memoTextField.returnKeyType = .done
     memoTextField.delegate = self
     memoTextField.autocorrectionType = .no
+    //文字列のながによる１文字あたりのサイズの自動調整
+    memoTextField.adjustsFontSizeToFitWidth = true
+    //最小サイズは10
+    memoTextField.minimumFontSize = 10
     
     let placeholderText = "ひとことメモ"
     let attributes = [

--- a/DietApp/View/TopPage/Cell/MemoTableViewCell.xib
+++ b/DietApp/View/TopPage/Cell/MemoTableViewCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="23094" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="23504" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23084"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23506"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -17,7 +17,7 @@
                 <rect key="frame" x="0.0" y="0.0" width="320" height="49"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <textField opaque="NO" tag="4" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="RAo-WU-Iqz">
+                    <textField opaque="NO" tag="4" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="center" minimumFontSize="10" translatesAutoresizingMaskIntoConstraints="NO" id="RAo-WU-Iqz">
                         <rect key="frame" x="0.0" y="1.5" width="320" height="46"/>
                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                         <textInputTraits key="textInputTraits"/>

--- a/DietApp/View/TopPage/Cell/WeightTableViewCell.swift
+++ b/DietApp/View/TopPage/Cell/WeightTableViewCell.swift
@@ -25,6 +25,13 @@ class WeightTableViewCell: UITableViewCell {
     weightTextField.keyboardType = .decimalPad
     
     weightTextField.autocorrectionType = .no
+    //2024.11.15
+    //文字列の長さによって１文字あたりのサイズを調整するかどうか
+    //falseなので調整をしない
+    //trueにすると、ペーストで値を入力した際にプレスホルダーのフォントサイズが変わってしまう
+    //原因は不明だが、このプロパティをfalseにしたら上記の現象が発生しなくなり、現状は体重テキストフィールドではサイズの調整は必要ないのでこの設定にしておく
+    //メモテキストフィールドでは上記の現象はいまのところ発生していないのでtrueにする
+    weightTextField.adjustsFontSizeToFitWidth = false
     
     let placeholderText = "体重を入力"
     let attributes = [

--- a/DietApp/View/TopPage/Cell/WeightTableViewCell.xib
+++ b/DietApp/View/TopPage/Cell/WeightTableViewCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="23094" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="23504" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23084"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23506"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -17,7 +17,7 @@
                 <rect key="frame" x="0.0" y="0.0" width="320" height="70"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <textField opaque="NO" tag="3" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="6Z2-CE-98M">
+                    <textField opaque="NO" tag="3" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="center" adjustsFontSizeToFit="NO" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="6Z2-CE-98M">
                         <rect key="frame" x="60" y="1.5" width="200" height="67"/>
                         <constraints>
                             <constraint firstAttribute="width" constant="200" id="DMO-2g-wKH"/>

--- a/DietAppTests/ModelTests/TopPageTextFieldValidationTest/MemoTextFieldValidationTest.swift
+++ b/DietAppTests/ModelTests/TopPageTextFieldValidationTest/MemoTextFieldValidationTest.swift
@@ -1,0 +1,116 @@
+//
+//  MemoTextFieldValidationTest.swift
+//  DietAppTests
+//
+//  Created by 川島真之 on 2024/11/10.
+//
+
+import XCTest
+@testable import DietApp
+
+final class MemoTextFieldValidationTest: XCTestCase {
+  
+  override func setUpWithError() throws {
+    // Put setup code here. This method is called before the invocation of each test method in the class.
+  }
+  
+  override func tearDownWithError() throws {
+    // Put teardown code here. This method is called after the invocation of each test method in the class.
+  }
+  //CharacterLengthValidator
+  //有効な値
+  func testCharacterLengthValidator_ValidInput_ShouldReturnValid(){
+    let validInputs = ["あ",
+                       "あいうえお",
+                       "aiueo",
+                       //３９文字
+                       "あいうえおかきくけこさしすせそたちつてとなにぬねのはひふへもまみむめもやゆよら",
+                       //40文字
+                       "あいうえおかきくけこさしすせそたちつてとなにぬねのはひふへもまみむめもやゆよらり",
+                       " ",
+                       "",
+                       "123"
+    ]
+    
+    validInputs.forEach{ input in
+      let validator = CharacterLengthValidator(memoString: input)
+      let result = validator.validate()
+      XCTAssertTrue(result.isValid, "Input \(input) は無効な値です")
+    }
+  }
+  //無効な値
+  func testCharacterLengthValidator_InvalidInput_ShouldReturnInvalid(){
+    //41文字
+    let invalidInputs = ["あいうえおかきくけこさしすせそたちつてとなにぬねのはひふへもまみむめもやゆよらりる",
+                         "あいうえおかきくけこさしすせそたちつてとなにぬねのはひふへもまみむめもやゆよらりるれろわをん"
+    ]
+    
+    invalidInputs.forEach { input in
+      let validator = CharacterLengthValidator(memoString: input)
+      let result = validator.validate()
+      XCTAssertFalse(result.isValid)
+    }
+  }
+  //NewLineValidator
+  //有効な値
+  func testNewLineValidator_ValidInput_ShouldReturnValid() {
+    let validInputs = ["あ",
+                      "あいうえお",
+                      "あ　いうえお",
+                      "123",
+                      "aiu",
+                      " ",
+                      ""
+    ]
+    
+    validInputs.forEach{ input in
+      let validator = NewLineValidator(memoString: input)
+      let result = validator.validate()
+      XCTAssertTrue(result.isValid, "Input \(input) は無効な値です")
+    }
+  }
+  //無効な値
+  func testNewLineValidator_InvalidInput_ShouldReturnInvalid() {
+    let invalidInputs = ["\n",
+                         "\nあいうえお",
+                         "あいうえお\nかきくけこ",
+                         "あいうえお\n",
+                         "あいうえお\nかきくけこ\nさしすせそ"
+    ]
+    
+    invalidInputs.forEach { input in
+      let validator = NewLineValidator(memoString: input)
+      let result = validator.validate()
+      XCTAssertFalse(result.isValid)
+    }
+  }
+  
+  func testMemoInputValidator_ValidInput_ShouldReturnValid() {
+    let validInputs = ["あいうえおかきくけこ",
+                       "あいうえお　かきくけこ",
+                       "aiu",
+                       "123",
+                       " ",
+                       ""
+    ]
+    
+    validInputs.forEach { input in
+      let validator = MemoInputValidator(text: input)
+      let result = validator.validate()
+      XCTAssertTrue(result.isValid, "Input \(input) は無効な値です")
+    }
+  }
+  
+  func testMemovalidator_InvalidInput_ShouldReturnInvalid() {
+    let testCases = [
+      ("あいうえおかきくけこさしすせそたちつてとなにぬねのはひふへもまみむめもやゆよらりるれろわをん", MemoValidationError.exceedsMaximumCharacterLength),
+      ("あいうえお\nかきくけこ\nさしすせそ", MemoValidationError.newLine)
+    ]
+    
+    testCases.forEach { input, expectedError in
+      let validator = MemoInputValidator(text: input)
+      let result = validator.validate()
+      XCTAssertFalse(result.isValid)
+    }
+  }
+}

--- a/DietAppTests/ModelTests/TopPageTextFieldValidationTest/WeightTextFieldValidationTest.swift
+++ b/DietAppTests/ModelTests/TopPageTextFieldValidationTest/WeightTextFieldValidationTest.swift
@@ -1,0 +1,185 @@
+//
+//  WeightTextFieldValidationTest.swift
+//  DietAppTests
+//
+//  Created by 川島真之 on 2024/11/08.
+//
+
+import XCTest
+@testable import DietApp
+
+final class WeightTextFieldValidationTest: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+  //WeightFormatValidator
+  //このvalodatorにおいて有効な値のテスト
+  //-50や50.55は最終的には無効な値だが、このvalidatorにおいては有効
+  func testWeightFormatValidator_ValidInput_ShouldReturnValid() {
+    let validInputs = ["50", "0", "-50", "50.5", "50.55"]
+    
+    validInputs.forEach { input in
+      let validator = WeightFormatValidator(weightString: input)
+      let result = validator.validate()
+      XCTAssertTrue(result.isValid, "Input \(input) は無効な値です")
+    }
+  }
+  //無効な値
+  func testWeightFormatValidator_InvalidInput_ShouldReturnInvalid() {
+    let invalidInputs = ["abc", "12.34.56", "@@", "50kg","😄"]
+    
+    invalidInputs.forEach { input in
+      let validator = WeightFormatValidator(weightString: input)
+      let result = validator.validate()
+      XCTAssertFalse(result.isValid)
+      //let result = validator.validate()でresultが.invalidの場合、その関連値（WeightValidationErrorのいずれかのケース）が
+      //.invalid(let error)のerrorに代入
+      if case .invalid(let error) = result {
+        //errorのWeightValidationErrorのケースが.invalidFormatになっているかを確認
+        //.invalidFormatになっていない　＝　エラーケースの種類違いということになる
+        XCTAssertEqual(error as? WeightValidationError, WeightValidationError.invalidFormat)
+      }
+    }
+  }
+  //NegativeNumberValidator
+  //有効な値かどうかを確認
+  func testNegativeNumberValidator_ValidInput_ShouldReturnValid() {
+    let validInputs = ["50", "0", "50.5", "50.55", ""]
+    
+    validInputs.forEach { input in
+      let validator = NegativeNumberValidator(weightString: input)
+      let result = validator.validate()
+      XCTAssertTrue(result.isValid, "Input \(input) は無効な値です")
+    }
+  }
+  //無効な値
+  func testNegativeNumberValidator_InvalidInput_ShouldReturnInvalid() {
+    let invalidInputs = ["-1", "-50", "-50.5"]
+    
+    invalidInputs.forEach { input in
+      let validator = NegativeNumberValidator(weightString: input)
+      let result = validator.validate()
+      XCTAssertFalse(result.isValid)
+      if case .invalid(let error) = result {
+        XCTAssertEqual(error as? WeightValidationError, WeightValidationError.negativeNumber)
+      }
+    }
+  }
+  //テキストがDouble型に変換できない場合
+  func testNegativeNumberValidator_NumberConversionFails_ShouldReturnInvalidFormat() {
+    let invalidConversionInputs = [ "abc", "  ", "1.1.1", "😄"]
+    
+    invalidConversionInputs.forEach { input in
+      let validator = NegativeNumberValidator(weightString: input)
+      let result = validator.validate()
+      
+      XCTAssertFalse(result.isValid, "Input '\(input)' should be invalid")
+      if case .invalid(let error) = result {
+        XCTAssertEqual(error as? WeightValidationError, WeightValidationError.invalidFormat,
+                       "Input '\(input)' はエラー（invalidFormat）を返すべきです")
+      } else {
+        XCTFail("Doubleに変換できています: \(input)")
+      }
+    }
+  }
+  //DecimalPlacesValidator
+  //有効な値
+  func testDecimalPlacesValidator_ValidInput_ShouldReturnValid() {
+    let validInputs = ["50", "50.5", "0.0", ""]
+    
+    validInputs.forEach { input in
+      let validator = DecimalPlacesValidator(weightString: input)
+      let result = validator.validate()
+      XCTAssertTrue(result.isValid, "Input \(input) は無効な値です")
+    }
+  }
+  //無効な値
+  func testDecimalPlacesValidator_InvalidInput_ShouldReturnInvalid() {
+    let invalidInputs = ["50.55", "50.00", "0.123"]
+    
+    invalidInputs.forEach { input in
+      let validator = DecimalPlacesValidator(weightString: input)
+      let result = validator.validate()
+      XCTAssertFalse(result.isValid)
+      if case .invalid(let error) = result {
+        XCTAssertEqual(error as? WeightValidationError, WeightValidationError.exceedsAllowedDecimalPlaces)
+      }
+    }
+  }
+  //testMaxWeightValidator
+  //有効な値
+  func testMaxWeightValidator_ValidInput_ShouldReturnValid() {
+    let validInputs = ["50", "299", "0", "300", ""]
+    
+    validInputs.forEach { input in
+      let validator = MaxWeightValidator(weightString: input)
+      let result = validator.validate()
+      XCTAssertTrue(result.isValid, "Input \(input) は無効な値です")
+    }
+  }
+  //無効な値
+  func testMaxWeightValidator_InvalidInput_ShouldReturnInvalid() {
+    let invalidInputs = ["301", "500"]
+    
+    invalidInputs.forEach { input in
+      let validator = MaxWeightValidator(weightString: input)
+      let result = validator.validate()
+      XCTAssertFalse(result.isValid)
+      if case .invalid(let error) = result {
+        XCTAssertEqual(error as? WeightValidationError, WeightValidationError.weightInputTooHigh)
+      }
+    }
+  }
+  //テキストがDouble型に変換できない場合
+  func testMaxWeightValidator_NumberConversionFails_ShouldReturnInvalidFormat() {
+    let invalidConversionInputs = [ "abc", "  ", "1.1.1", "😄"]
+    
+    invalidConversionInputs.forEach { input in
+      let validator = MaxWeightValidator(weightString: input)
+      let result = validator.validate()
+      
+      XCTAssertFalse(result.isValid, "Input '\(input)' should be invalid")
+      if case .invalid(let error) = result {
+        XCTAssertEqual(error as? WeightValidationError, WeightValidationError.invalidFormat,
+                       "Input '\(input)' はエラー（invalidFormat）を返すべきです")
+      } else {
+        XCTFail("Doubleに変換できています: \(input)")
+      }
+    }
+  }
+  //testWeightInputValidator
+  //各validatorの総合テスト
+  //有効な値
+  func testWeightInputValidator_ValidInput_ShouldReturnValid() {
+    let validInputs = ["50", "50.5", "299.9", "0.0"]
+    
+    validInputs.forEach { input in
+      let validator = WeightInputValidator(text: input)
+      let result = validator.validate()
+      XCTAssertTrue(result.isValid, "Input \(input) は無効な値です")
+    }
+  }
+  //無効な値
+  func testWeightInputValidator_InvalidInput_ShouldReturnInvalid() {
+    let testCases = [
+      ("abc", WeightValidationError.invalidFormat),
+      ("-1", WeightValidationError.negativeNumber),
+      ("50.55", WeightValidationError.exceedsAllowedDecimalPlaces),
+      ("301", WeightValidationError.weightInputTooHigh)
+    ]
+    
+    testCases.forEach { input, expectedError in
+      let validator = WeightInputValidator(text: input)
+      let result = validator.validate()
+      XCTAssertFalse(result.isValid)
+      if case .invalid(let error) = result {
+        XCTAssertEqual(error as? WeightValidationError, expectedError)
+      }
+    }
+  }
+}


### PR DESCRIPTION
## issue
close #112 

## 概要
テキストフィールドにペーストで値を入力した際に、プレスホルダーのフォントサイズが大きくなってしまう問題に対処した。

## 問題の具体的情報
体重テキストフィールドにある程度長い文字列をペーストしアラートを発生させ、その後テキストフィールドが空になった時、プレスホルダーのフォントサイズが入力されるテキストのフォントサイズと同じサイズまで大きくなっていた。

## 対処方法
WeightTableViewCellのawakeFromNib()内に以下のコードを追加し、テキストフィールドに入力された文字列の長さによって、１文字あたりのサイズが自動調整されないようにした。なお、IBでも同様の設定箇所をオフにした。
``
weightTextField.adjustsFontSizeToFitWidth = false
``

## 対処までの流れ
1. まず、プレスホルダーのフォントサイズをテキストフィールドの入力が終わった段階で元のフォントサイズに再設定すればよいのではと考え、再設定のメソッドを作りテキスト編集完了時のデリゲートメソッド内に実装したが何も変わらず。
2. 次にそもそもテキストフィールドにペーストをできないようにすれば良いと考え、以下の記事を参考に実装したがうまくいかない。
[https://qiita.com/masssun/items/fce210c2b27d9fe61fcd](url)
編集アクションのペーストを無効にしようとしたが、ペーストができてしまっている。原因を調査したが判明しなかったので一旦このアプローチは保留した。
3. 問題の現象を再度確認し、ある程度の長さの文字列が代入された場合にこの現象が起こっているのではないかと仮定し、文字サイズの自動調整を一旦オフにしてみたところ問題が発生しなくなった。
現状では体重テキストフィールドに入力された文字のサイズは自動調整されなくても構わないため、この仕様でやっていくことにした。

## 今後について
この対処法は正攻法ではないような気がするので、余裕があれば再度この問題について調査したい。