### PR TITLE
トップの写真セルの削除ボタンと拡大ボタンのタップアクションを実装した。

### DIFF
--- a/DietApp/TopPage/TopViewController.swift
+++ b/DietApp/TopPage/TopViewController.swift
@@ -238,6 +238,14 @@ extension TopViewController: WeightTableViewCellDelegate, MemoTableViewCellDeleg
 }
 //写真セル内のボタン押下時処理
 extension TopViewController: PhotoTableViewCellDelegate, UIImagePickerControllerDelegate, UINavigationControllerDelegate {
+  //拡大ボタンが押された時の処理
+  func expandButtonAction(photoImage: UIImage) {
+    showPhotoModal(photoImage: photoImage)
+  }
+  
+  func deleteButtonAction() {
+    return
+  }
   //写真挿入ボタンとやり直しボタンを押した時の処理
   func insertButtonAction() {
     showPhotoSelectionActionSheet()

--- a/DietApp/View/TopPage/Cell/PhotoTableViewCell.swift
+++ b/DietApp/View/TopPage/Cell/PhotoTableViewCell.swift
@@ -10,7 +10,7 @@ import UIKit
 protocol PhotoTableViewCellDelegate {
   func insertButtonAction()
   func expandButtonAction(photoImage: UIImage)
-  func deleteButtonAction()
+  func deleteButtonAction(in cell: PhotoTableViewCell)
   func photoDoubleTapAction(photoImage: UIImage)
 }
 //このエクステンションの記述場所は後日変更
@@ -165,6 +165,7 @@ class PhotoTableViewCell: UITableViewCell {
   }
   
   @IBAction func deleteButtonAction(_ sender: Any) {
+    delegate?.deleteButtonAction(in: self)
   }
   
   @objc func  photoDoubleTapAction() {

--- a/DietApp/View/TopPage/Cell/PhotoTableViewCell.swift
+++ b/DietApp/View/TopPage/Cell/PhotoTableViewCell.swift
@@ -9,6 +9,8 @@ import UIKit
 
 protocol PhotoTableViewCellDelegate {
   func insertButtonAction()
+  func expandButtonAction(photoImage: UIImage)
+  func deleteButtonAction()
   func photoDoubleTapAction(photoImage: UIImage)
 }
 //このエクステンションの記述場所は後日変更
@@ -153,6 +155,16 @@ class PhotoTableViewCell: UITableViewCell {
   
   @IBAction func redoButtonAction(_ sender: Any) {
     delegate?.insertButtonAction()
+  }
+  @IBAction func expandButtonAction(_ sender: Any) {
+    if let image = photoImageView.image  {
+      delegate?.expandButtonAction(photoImage: image)
+    }else {
+      return
+    }
+  }
+  
+  @IBAction func deleteButtonAction(_ sender: Any) {
   }
   
   @objc func  photoDoubleTapAction() {

--- a/DietApp/View/TopPage/Cell/PhotoTableViewCell.xib
+++ b/DietApp/View/TopPage/Cell/PhotoTableViewCell.xib
@@ -57,6 +57,9 @@
                         </constraints>
                         <state key="normal" title="Button"/>
                         <buttonConfiguration key="configuration" style="plain" image="plus.magnifyingglass" catalog="system"/>
+                        <connections>
+                            <action selector="expandButtonAction:" destination="KGk-i7-Jjw" eventType="touchUpInside" id="xBX-Qf-RVM"/>
+                        </connections>
                     </button>
                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ygx-GC-9Wu">
                         <rect key="frame" x="266" y="346" width="44" height="44"/>
@@ -66,6 +69,9 @@
                         </constraints>
                         <state key="normal" title="Button"/>
                         <buttonConfiguration key="configuration" style="plain" image="trash.fill" catalog="system"/>
+                        <connections>
+                            <action selector="deleteButtonAction:" destination="KGk-i7-Jjw" eventType="touchUpInside" id="f77-m2-bfc"/>
+                        </connections>
                     </button>
                 </subviews>
                 <constraints>

--- a/TopPageTextFieldTag.swift
+++ b/TopPageTextFieldTag.swift
@@ -1,8 +1,0 @@
-//
-//  TopPageTextFieldTag.swift
-//  
-//
-//  Created by 川島真之 on 2024/11/12.
-//
-
-import Foundation


### PR DESCRIPTION
## issue
close #120

## 作業内容
- **削除ボタン**
削除ボタンをタップした時、写真セルにセットされている写真を削除し、　Realm内のパスとドキュメント内の写真も削除するようにした。加えて写真セル内のボタンの表示、非表示を調整した。

- **拡大ボタン**
拡大ボタンをタップした時、写真表示用のモーダルを表示するようにした。