### PR TITLE
写真セルのinsertButtonのUIデザインを調整した 他

### DIFF
--- a/DietApp/Model/Logic/TopPageTextFieldValidation/WeightTextFieldValidation.swift
+++ b/DietApp/Model/Logic/TopPageTextFieldValidation/WeightTextFieldValidation.swift
@@ -36,7 +36,7 @@ extension WeightValidationError: LocalizedError {
   public var errorDescription: String? {
     switch self {
     case .invalidFormat:
-      return "入力できる文字は数字のみです"
+      return "無効な値が入力されました"
     case .negativeNumber:
       return "マイナスの数字は入力できません"
     case .exceedsAllowedDecimalPlaces:

--- a/DietApp/TopPage/TopNavigationController.swift
+++ b/DietApp/TopPage/TopNavigationController.swift
@@ -12,6 +12,13 @@ class TopNavigationController: UINavigationController {
     override func viewDidLoad() {
         super.viewDidLoad()
         // Do any additional setup after loading the view.
+      
+//      let appearance = UINavigationBarAppearance()
+//      appearance.backgroundColor = .systemBlue
+//      appearance.configureWithOpaqueBackground()
+//      
+//      navigationBar.standardAppearance = appearance
+//      navigationBar.scrollEdgeAppearance = appearance
     }
     
 

--- a/DietApp/TopPage/TopPageViewController.swift
+++ b/DietApp/TopPage/TopPageViewController.swift
@@ -11,7 +11,6 @@ class TopPageViewController: UIPageViewController {
  
   var controllers: [TopViewController] = []
 
-  
   override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
     return .portrait
   }
@@ -95,6 +94,7 @@ extension TopPageViewController: UIPageViewControllerDelegate {
 extension TopPageViewController {
   //titileの設定
   func navigationBarTitleSetting (currentDate: Date){
+    
     var yearText = ""
     var dateText = ""
     var dayOfWeekText = ""

--- a/DietApp/TopPage/TopViewController.swift
+++ b/DietApp/TopPage/TopViewController.swift
@@ -283,8 +283,8 @@ extension TopViewController: PhotoTableViewCellDelegate, UIImagePickerController
         cell.photoImageView.image = nil
       }
     }
-    print("なんらかの理由で画像が削除できませんでした")
   }
+  
   //写真挿入ボタンとやり直しボタンを押した時の処理
   func insertButtonAction() {
     showPhotoSelectionActionSheet()

--- a/DietApp/View/Base.lproj/Main.storyboard
+++ b/DietApp/View/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23094" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="F92-bx-bHI">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23504" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="F92-bx-bHI">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23084"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23506"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -121,7 +121,7 @@
                         <autoresizingMask key="autoresizingMask"/>
                         <navigationBarAppearance key="standardAppearance"/>
                         <navigationBarAppearance key="scrollEdgeAppearance">
-                            <color key="backgroundColor" systemColor="systemGroupedBackgroundColor"/>
+                            <color key="backgroundColor" systemColor="systemGray6Color"/>
                         </navigationBarAppearance>
                     </navigationBar>
                     <nil name="viewControllers"/>
@@ -188,9 +188,6 @@
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>
         <systemColor name="systemGray6Color">
-            <color red="0.94901960780000005" green="0.94901960780000005" blue="0.96862745100000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-        </systemColor>
-        <systemColor name="systemGroupedBackgroundColor">
             <color red="0.94901960780000005" green="0.94901960780000005" blue="0.96862745100000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
         <systemColor name="tertiarySystemGroupedBackgroundColor">

--- a/DietApp/View/TopPage/Cell/AdTableViewCell.xib
+++ b/DietApp/View/TopPage/Cell/AdTableViewCell.xib
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="23504" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23506"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -19,7 +20,7 @@
                 <subviews>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="cjB-mt-U66">
                         <rect key="frame" x="0.0" y="1.5" width="320" height="52"/>
-                        <color key="backgroundColor" systemColor="systemCyanColor"/>
+                        <color key="backgroundColor" systemColor="systemGray3Color"/>
                     </view>
                 </subviews>
                 <constraints>
@@ -34,8 +35,8 @@
         </tableViewCell>
     </objects>
     <resources>
-        <systemColor name="systemCyanColor">
-            <color red="0.19607843137254902" green="0.67843137254901964" blue="0.90196078431372551" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        <systemColor name="systemGray3Color">
+            <color red="0.78039215689999997" green="0.78039215689999997" blue="0.80000000000000004" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/DietApp/View/TopPage/Cell/MemoTableViewCell.swift
+++ b/DietApp/View/TopPage/Cell/MemoTableViewCell.swift
@@ -29,7 +29,7 @@ class MemoTableViewCell: UITableViewCell {
     //最小サイズは10
     memoTextField.minimumFontSize = 10
     
-    let placeholderText = "ひとことメモ"
+    let placeholderText = "ひとことメモを入力"
     let attributes = [
         NSAttributedString.Key.font: UIFont.systemFont(ofSize: 14)
     ]

--- a/DietApp/View/TopPage/Cell/PhotoTableViewCell.swift
+++ b/DietApp/View/TopPage/Cell/PhotoTableViewCell.swift
@@ -18,7 +18,7 @@ extension UIButton {
   //非アクティブ状態のボタンの外観の設定
   func configureDisabledButtonAppearance() {
     self.tintColor = UIColor.systemGray.withAlphaComponent(0.3)
-    self.backgroundColor = UIColor.systemGray3.withAlphaComponent(0.4)
+    self.backgroundColor = UIColor.systemGray5
   }
   //アクティブ状態のボタンの外観の設定
   func configureEnabledButtonAppearance() {
@@ -34,7 +34,7 @@ extension UIButton {
   ///   - cornerRadius: 角丸の半径（デフォルトはボタンの幅の半分）
   func applyFrostedGlassEffect(
     _ style: UIBlurEffect.Style = .light,
-    _ alpha: CGFloat = 0.5,
+    _ alpha: CGFloat = 0.8,
     _ cornerRadius: CGFloat? = nil
   ) {
     // 既存のフロストエフェクトを削除（重複防止）
@@ -90,11 +90,7 @@ class PhotoTableViewCell: UITableViewCell {
   @IBOutlet weak var redoButton: UIButton!
   @IBOutlet weak var deleteButton: UIButton!
   @IBOutlet weak var expandButton: UIButton!
-  
-  var isRedoButtonConfigured = false
-  var isdeleteButtonConfigured = false
-  var isexpandButtontonConfigured = false
-  
+
   var delegate: PhotoTableViewCellDelegate?
   
   override func awakeFromNib() {
@@ -106,21 +102,32 @@ class PhotoTableViewCell: UITableViewCell {
     let symbolConfiguration = UIImage.SymbolConfiguration(pointSize: 40)
     let image = insertButton.image(for: .normal)?.withConfiguration(symbolConfiguration)
     insertButton.setImage(image, for: .normal)
-    
     insertButton.imageView?.contentMode = .scaleAspectFit
+    let radius = insertButton.frame.size.width / 2
+    insertButton.layer.cornerRadius = radius
+    insertButton.backgroundColor = UIColor.white
     
+    insertButton.layer.shadowColor = UIColor.gray.cgColor  // 影の色
+    insertButton.layer.shadowOffset = CGSize(width: 0, height: 1)  // 影のオフセット
+    insertButton.layer.shadowRadius =  1  // 影のぼかし具合
+    insertButton.layer.shadowOpacity = 0.5  // 影の透明度
+    
+//    if let imageView = insertButton.imageView {
+//      imageView.layer.shadowColor = UIColor.gray.cgColor
+//      imageView.layer.shadowOpacity = 0.5
+//      imageView.layer.shadowOffset = CGSize(width: 0, height: 1)
+//      imageView.layer.shadowRadius = 1.5
+//    }
+//    
     redoButton.setCornerRadius()
     redoButton.configureDisabledButtonAppearance()
-    isRedoButtonConfigured = true
     
     deleteButton.setCornerRadius()
     deleteButton.configureDisabledButtonAppearance()
-    isdeleteButtonConfigured = true
     
     expandButton.setCornerRadius()
     expandButton.configureDisabledButtonAppearance()
-    isexpandButtontonConfigured = true
-    
+
     redoButton.isUserInteractionEnabled = false
     deleteButton.isUserInteractionEnabled = false
     expandButton.isUserInteractionEnabled = false

--- a/DietApp/View/TopPage/Cell/PhotoTableViewCell.xib
+++ b/DietApp/View/TopPage/Cell/PhotoTableViewCell.xib
@@ -34,14 +34,12 @@
                             <action selector="redoButtonAction:" destination="KGk-i7-Jjw" eventType="touchUpInside" id="DYG-m8-sI3"/>
                         </connections>
                     </button>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="タップして写真を挿入" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DL6-uU-7i8">
-                        <rect key="frame" x="99" y="217.5" width="122" height="16"/>
-                        <fontDescription key="fontDescription" type="system" pointSize="13"/>
-                        <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                        <nil key="highlightedColor"/>
-                    </label>
                     <button opaque="NO" contentMode="scaleAspectFit" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="oKB-hh-oFN">
-                        <rect key="frame" x="144.5" y="188" width="31.5" height="24.5"/>
+                        <rect key="frame" x="100" y="140" width="120" height="120"/>
+                        <constraints>
+                            <constraint firstAttribute="width" constant="120" id="4Jz-DC-bxy"/>
+                            <constraint firstAttribute="height" constant="120" id="Fou-OG-b1t"/>
+                        </constraints>
                         <fontDescription key="fontDescription" type="system" pointSize="15"/>
                         <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
                         <state key="normal" image="camera" catalog="system"/>
@@ -73,10 +71,18 @@
                             <action selector="deleteButtonAction:" destination="KGk-i7-Jjw" eventType="touchUpInside" id="f77-m2-bfc"/>
                         </connections>
                     </button>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="タップして写真をセット" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DL6-uU-7i8">
+                        <rect key="frame" x="93" y="268" width="134" height="16"/>
+                        <fontDescription key="fontDescription" type="system" pointSize="13"/>
+                        <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <nil key="highlightedColor"/>
+                    </label>
                 </subviews>
                 <constraints>
+                    <constraint firstItem="oKB-hh-oFN" firstAttribute="centerY" secondItem="H2p-sc-9uM" secondAttribute="centerY" id="5Vp-cd-3ho"/>
+                    <constraint firstItem="DL6-uU-7i8" firstAttribute="top" secondItem="oKB-hh-oFN" secondAttribute="bottom" constant="8" symbolic="YES" id="9Ez-9h-y9e"/>
+                    <constraint firstItem="oKB-hh-oFN" firstAttribute="centerX" secondItem="H2p-sc-9uM" secondAttribute="centerX" id="BM5-hy-1K4"/>
                     <constraint firstItem="DL6-uU-7i8" firstAttribute="centerX" secondItem="H2p-sc-9uM" secondAttribute="centerX" id="Ir6-0J-1cD"/>
-                    <constraint firstItem="oKB-hh-oFN" firstAttribute="centerX" secondItem="H2p-sc-9uM" secondAttribute="centerX" id="Iyb-zC-eO7"/>
                     <constraint firstAttribute="bottom" secondItem="rrK-eD-DU2" secondAttribute="bottom" constant="1.5" id="Kft-iq-6A3"/>
                     <constraint firstItem="ygx-GC-9Wu" firstAttribute="leading" secondItem="Ytx-di-uC3" secondAttribute="trailing" constant="5" id="QSa-9Y-Ven"/>
                     <constraint firstAttribute="trailing" secondItem="rrK-eD-DU2" secondAttribute="trailing" id="Qs1-TQ-HVp"/>
@@ -85,8 +91,6 @@
                     <constraint firstItem="rrK-eD-DU2" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="1.5" id="ffh-RN-yVf"/>
                     <constraint firstItem="rrK-eD-DU2" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="rto-7n-huu"/>
                     <constraint firstAttribute="bottom" secondItem="Tvr-hc-Pm0" secondAttribute="bottom" constant="10" id="s7k-6m-zKV"/>
-                    <constraint firstItem="DL6-uU-7i8" firstAttribute="top" secondItem="oKB-hh-oFN" secondAttribute="bottom" constant="5" id="se1-Iw-BEo"/>
-                    <constraint firstItem="oKB-hh-oFN" firstAttribute="centerY" secondItem="H2p-sc-9uM" secondAttribute="centerY" id="tXL-IB-RQi"/>
                     <constraint firstItem="Ytx-di-uC3" firstAttribute="leading" secondItem="Tvr-hc-Pm0" secondAttribute="trailing" constant="5" id="uh6-nJ-dGj"/>
                     <constraint firstAttribute="trailing" secondItem="ygx-GC-9Wu" secondAttribute="trailing" constant="10" id="utE-AZ-xll"/>
                 </constraints>


### PR DESCRIPTION
## issue
close #126 

## 内容

- 写真セルの写真挿入ボタンのUIデザインを調整した。
<img width="319" alt="スクリーンショット 2024-11-22 22 39 14" src="https://github.com/user-attachments/assets/5dcc827c-77c2-4046-8a17-69dfcd4c0b4d">


- 体重テキストフィールドのバリデーションの.invalidFormatのエラーメッセージを"無効な値が入力されました"に変更した。