### PR TITLE
削除前後のアラートとデータ削除のモデルの作成を作成した。

### DIFF
--- a/DietApp.xcodeproj/project.pbxproj
+++ b/DietApp.xcodeproj/project.pbxproj
@@ -29,7 +29,6 @@
 		FA22111B2CFF5E4E005C622D /* NotificationTimeEditTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA2211192CFF5E4E005C622D /* NotificationTimeEditTableViewCell.swift */; };
 		FA22111C2CFF5E4E005C622D /* NotificationTimeEditTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = FA22111A2CFF5E4E005C622D /* NotificationTimeEditTableViewCell.xib */; };
 		FA24A8732CA66F110082AF19 /* OrientationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA24A8722CA66F110082AF19 /* OrientationManager.swift */; };
-		FA24A8792CA6C8EF0082AF19 /* GraphNavigationControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA24A8782CA6C8EF0082AF19 /* GraphNavigationControllerTests.swift */; };
 		FA24A87E2CA6EC100082AF19 /* AppDelegateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA24A87D2CA6EC100082AF19 /* AppDelegateTests.swift */; };
 		FA32F4B62A32BCF50058FD32 /* SettingsView.xib in Resources */ = {isa = PBXBuildFile; fileRef = FA32F4B52A32BCF50058FD32 /* SettingsView.xib */; };
 		FA32F4B82A32BD130058FD32 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA32F4B72A32BD130058FD32 /* SettingsView.swift */; };
@@ -87,6 +86,8 @@
 		FAC9EF432D0C562E00DE1E64 /* DataDeletionExecutionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAC9EF422D0C562E00DE1E64 /* DataDeletionExecutionView.swift */; };
 		FAC9EF452D0C564100DE1E64 /* DataDeletionExecutionView.xib in Resources */ = {isa = PBXBuildFile; fileRef = FAC9EF442D0C564100DE1E64 /* DataDeletionExecutionView.xib */; };
 		FAC9EF472D0C5A6F00DE1E64 /* DataDeletionExecutionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAC9EF462D0C5A6F00DE1E64 /* DataDeletionExecutionViewController.swift */; };
+		FAC9EF4B2D0E498E00DE1E64 /* DataDeleteManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAC9EF4A2D0E498E00DE1E64 /* DataDeleteManager.swift */; };
+		FAC9EF4D2D0EA98F00DE1E64 /* DataDeleteManagerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAC9EF4C2D0EA98F00DE1E64 /* DataDeleteManagerTest.swift */; };
 		FAFF6F532A2055430092A1A3 /* TopView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAFF6F522A2055430092A1A3 /* TopView.swift */; };
 		FAFF6F552A2055590092A1A3 /* TopView.xib in Resources */ = {isa = PBXBuildFile; fileRef = FAFF6F542A2055590092A1A3 /* TopView.xib */; };
 		FAFF6F592A21ACE40092A1A3 /* WeightTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAFF6F572A21ACE40092A1A3 /* WeightTableViewCell.swift */; };
@@ -140,7 +141,6 @@
 		FA2211192CFF5E4E005C622D /* NotificationTimeEditTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationTimeEditTableViewCell.swift; sourceTree = "<group>"; };
 		FA22111A2CFF5E4E005C622D /* NotificationTimeEditTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = NotificationTimeEditTableViewCell.xib; sourceTree = "<group>"; };
 		FA24A8722CA66F110082AF19 /* OrientationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrientationManager.swift; sourceTree = "<group>"; };
-		FA24A8782CA6C8EF0082AF19 /* GraphNavigationControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphNavigationControllerTests.swift; sourceTree = "<group>"; };
 		FA24A87D2CA6EC100082AF19 /* AppDelegateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegateTests.swift; sourceTree = "<group>"; };
 		FA32F4B52A32BCF50058FD32 /* SettingsView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SettingsView.xib; sourceTree = "<group>"; };
 		FA32F4B72A32BD130058FD32 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
@@ -202,6 +202,8 @@
 		FAC9EF422D0C562E00DE1E64 /* DataDeletionExecutionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataDeletionExecutionView.swift; sourceTree = "<group>"; };
 		FAC9EF442D0C564100DE1E64 /* DataDeletionExecutionView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = DataDeletionExecutionView.xib; sourceTree = "<group>"; };
 		FAC9EF462D0C5A6F00DE1E64 /* DataDeletionExecutionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataDeletionExecutionViewController.swift; sourceTree = "<group>"; };
+		FAC9EF4A2D0E498E00DE1E64 /* DataDeleteManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataDeleteManager.swift; sourceTree = "<group>"; };
+		FAC9EF4C2D0EA98F00DE1E64 /* DataDeleteManagerTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataDeleteManagerTest.swift; sourceTree = "<group>"; };
 		FAFF6F522A2055430092A1A3 /* TopView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopView.swift; sourceTree = "<group>"; };
 		FAFF6F542A2055590092A1A3 /* TopView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = TopView.xib; sourceTree = "<group>"; };
 		FAFF6F572A21ACE40092A1A3 /* WeightTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeightTableViewCell.swift; sourceTree = "<group>"; };
@@ -283,6 +285,7 @@
 				FA417BBF2A5C428E00B53A0F /* DateDataRealmSearcher.swift */,
 				FA24A8722CA66F110082AF19 /* OrientationManager.swift */,
 				FAC9EF2C2D0C11C200DE1E64 /* LocalNotificationManager.swift */,
+				FAC9EF4A2D0E498E00DE1E64 /* DataDeleteManager.swift */,
 				FAC9EF282D0C11A000DE1E64 /* Data */,
 				FA10AD172CDDC5E800AF9404 /* TopPageTextFieldValidation */,
 			);
@@ -324,14 +327,6 @@
 				FA24A87D2CA6EC100082AF19 /* AppDelegateTests.swift */,
 			);
 			path = AppDelegateTests;
-			sourceTree = "<group>";
-		};
-		FA24A8752CA6C2450082AF19 /* GraphPageTests */ = {
-			isa = PBXGroup;
-			children = (
-				FA24A8782CA6C8EF0082AF19 /* GraphNavigationControllerTests.swift */,
-			);
-			path = GraphPageTests;
 			sourceTree = "<group>";
 		};
 		FA32F4B02A32BBAE0058FD32 /* SettingsPage */ = {
@@ -381,6 +376,7 @@
 				FA42FA2E2A6B6CB700C60F9E /* DateDataRealmSearcherTests.swift */,
 				FA42FA2C2A6A4C1200C60F9E /* IndexSetterTests.swift */,
 				FA42FA492A7F3BE600C60F9E /* MonthAdjusterTests.swift */,
+				FAC9EF4C2D0EA98F00DE1E64 /* DataDeleteManagerTest.swift */,
 				FA55F5B42CE58D080015291F /* TopPageTextFieldValidationTest */,
 			);
 			path = ModelTests;
@@ -436,7 +432,6 @@
 		FA68AF362A135F7200B69D4A /* DietAppTests */ = {
 			isa = PBXGroup;
 			children = (
-				FA24A8752CA6C2450082AF19 /* GraphPageTests */,
 				FA24A8742CA6C2100082AF19 /* AppDelegateTests */,
 				FA42FA342A6CE85600C60F9E /* ModelTests */,
 			);
@@ -910,6 +905,7 @@
 				FAC9EF232D0C0B5C00DE1E64 /* TabBarController.swift in Sources */,
 				FA68AF212A135F6F00B69D4A /* AppDelegate.swift in Sources */,
 				FABF36082A283CD0007D91DB /* GraphView.swift in Sources */,
+				FAC9EF4B2D0E498E00DE1E64 /* DataDeleteManager.swift in Sources */,
 				FA22110D2CFF16D6005C622D /* MainBackgroundView.swift in Sources */,
 				FAC9EF312D0C11E900DE1E64 /* GraphDateManager.swift in Sources */,
 				FA42FA522A81D8CC00C60F9E /* CustomMarkerView.swift in Sources */,
@@ -940,8 +936,8 @@
 				FA42FA2F2A6B6CB700C60F9E /* DateDataRealmSearcherTests.swift in Sources */,
 				FA42FA3C2A70BD4100C60F9E /* DateRangeCalculatorTests.swift in Sources */,
 				FA10AD1E2CDDDBDF00AF9404 /* WeightTextFieldValidationTest.swift in Sources */,
-				FA24A8792CA6C8EF0082AF19 /* GraphNavigationControllerTests.swift in Sources */,
 				FA42FA332A6CB76200C60F9E /* GraphContentCreatorTests.swift in Sources */,
+				FAC9EF4D2D0EA98F00DE1E64 /* DataDeleteManagerTest.swift in Sources */,
 				FA42FA2D2A6A4C1200C60F9E /* IndexSetterTests.swift in Sources */,
 				FA24A87E2CA6EC100082AF19 /* AppDelegateTests.swift in Sources */,
 				FA42FA4A2A7F3BE600C60F9E /* MonthAdjusterTests.swift in Sources */,
@@ -1179,7 +1175,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.5;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.gmail.mkogori01.DietAppTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1199,7 +1195,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.5;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.gmail.mkogori01.DietAppTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/DietApp/Controller/SettingsPage/DataDeletionExecutionViewController.swift
+++ b/DietApp/Controller/SettingsPage/DataDeletionExecutionViewController.swift
@@ -72,6 +72,7 @@ extension DataDeletionExecutionViewController: UITableViewDelegate,UITableViewDa
       let cell = tableView.dequeueReusableCell(withIdentifier: "DeleteAllDataTableViewCell", for: indexPath) as! DeleteAllDataTableViewCell
       
       cell.selectionStyle = UITableViewCell.SelectionStyle.none
+      cell.delegate = self
       return cell
       
     default :
@@ -82,4 +83,39 @@ extension DataDeletionExecutionViewController: UITableViewDelegate,UITableViewDa
   func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
     return TableViewCellHeight
   }
+}
+
+extension DataDeletionExecutionViewController: DeleteAllDataTableViewCellDelegate {
+  
+  func deleteButtonAction() {
+    print("aaaaaaaa")
+    showConfirmationAlert()
+  }
+  
+  func showConfirmationAlert() {
+    let alert = UIAlertController(title: nil, message: "全てのデータを削除してもよろしいですか この操作は取り消せません", preferredStyle: .alert)
+    
+    let titleAttributes = [NSAttributedString.Key.foregroundColor: UIColor.red]
+    let attributedTitle = NSAttributedString(string: "警告", attributes: titleAttributes)
+    alert.setValue(attributedTitle, forKey: "attributedTitle")
+    
+    let cancelAction = UIAlertAction(title: "キャンセル", style: .cancel)
+    let deleteAction = UIAlertAction(title: "削除する", style: .destructive) { _ in
+      self.showDeletionCompletedAlert()
+    }
+    
+    alert.addAction(cancelAction)
+    alert.addAction(deleteAction)
+    self.present(alert, animated: true)
+  }
+  
+  func showDeletionCompletedAlert() {
+    let alert = UIAlertController(title: nil, message: "全てのデータが削除されました", preferredStyle: .alert)
+    
+    let okAction = UIAlertAction(title: "OK", style: .default)
+    alert.addAction(okAction)
+    
+    self.present(alert, animated: true)
+  }
+  
 }

--- a/DietApp/Controller/SettingsPage/DataDeletionExecutionViewController.swift
+++ b/DietApp/Controller/SettingsPage/DataDeletionExecutionViewController.swift
@@ -88,7 +88,6 @@ extension DataDeletionExecutionViewController: UITableViewDelegate,UITableViewDa
 extension DataDeletionExecutionViewController: DeleteAllDataTableViewCellDelegate {
   
   func deleteButtonAction() {
-    print("aaaaaaaa")
     showConfirmationAlert()
   }
   

--- a/DietApp/Controller/TopPage/TopViewController.swift
+++ b/DietApp/Controller/TopPage/TopViewController.swift
@@ -248,8 +248,8 @@ extension TopViewController: PhotoTableViewCellDelegate, UIImagePickerController
   }
   
   func deleteButtonAction(in cell: PhotoTableViewCell) {
-    let alert = UIAlertController(title: "確認", message: "写真を削除してもよろしいですか？", preferredStyle: .alert)
-    let okAction = UIAlertAction(title: "OK", style: .destructive) { _ in
+    let alert = UIAlertController(title: nil, message: "写真を削除してもよろしいですか？", preferredStyle: .alert)
+    let okAction = UIAlertAction(title: "削除する", style: .destructive) { _ in
       self.deleteAlertAction(cell)
     }
     let cancelAction = UIAlertAction(title: "キャンセル", style: .cancel)

--- a/DietApp/Controller/TopPage/TopViewController.swift
+++ b/DietApp/Controller/TopPage/TopViewController.swift
@@ -408,7 +408,6 @@ extension TopViewController: PhotoTableViewCellDelegate, UIImagePickerController
       print("画像をドキュメントに保存できませんでした")
     }
   }
-  //写真のファイルと、ドキュメントへの保存のためフルパスの作成
 }
 //各TextFieldのイベント処理
 extension TopViewController: UITextFieldDelegate {

--- a/DietApp/Info.plist
+++ b/DietApp/Info.plist
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSUserNotificationsUsageDescription</key>
+	<string>記録時間の通知のため、許可が必要です</string>
+	<key>CFBundleIdentifier</key>
+	<string></string>
 	<key>CFBundleLocalizations</key>
 	<array>
 		<string>ja</string>

--- a/DietApp/Model/Logic/DataDeleteManager.swift
+++ b/DietApp/Model/Logic/DataDeleteManager.swift
@@ -1,0 +1,72 @@
+//
+//  DataDeleteManager.swift
+//  DietApp
+//
+//  Created by 川島真之 on 2024/12/15.
+//
+
+import Foundation
+import RealmSwift
+
+class DataDeleteManager {
+  
+  static let shared = DataDeleteManager()
+  private let fileManager = FileManager.default
+  private let realm = try! Realm()
+  private init() {}
+  
+  private func clearDocumentDirectroy() -> Bool {
+    do {
+      //ドキュメントディレクトリのパスを取得
+      guard let documentPath = fileManager.urls(for: .documentDirectory, in: .userDomainMask).first else {
+        print("❌ ドキュメントディレクトリが見つかりません")
+        return false }
+      //ドキュメントディレクトリ内の全てのアイテムを取得
+      let contents = try fileManager.contentsOfDirectory(at: documentPath, includingPropertiesForKeys: nil, options: [])
+      
+      if contents.isEmpty {
+        print("ℹ️ ドキュメントディレクトリは既に空です")
+        return true
+      }
+      
+      try contents.forEach { url in
+        try fileManager.removeItem(at: url)
+        print("✅ 削除成功: \(url.lastPathComponent)")
+      }
+      
+      return true
+      //エラー処理
+    } catch {
+      print("❌ ディレクトリファイルの削除中にエラーが発生しました: \(error.localizedDescription)")
+      return false
+    }
+  }
+  
+  private func deleteRealmObject() -> Bool {
+    
+    if realm.isEmpty {
+      print("ℹ️ Realmデータベースは既に空です")
+      return true
+    }
+     
+    do {
+      try realm.write {
+        realm.deleteAll()
+      }
+    } catch {
+      print("❌ RealmObjectの削除ができませんでした: \(error.localizedDescription)")
+      return false
+    }
+    return true
+  }
+  
+  func deleteAllData() -> Bool {
+    let DeleteRealmObjectResult = deleteRealmObject()
+    let clearDocumentDirectoryResult = clearDocumentDirectroy()
+    
+    if DeleteRealmObjectResult && clearDocumentDirectoryResult {
+      return true
+    }
+    return false
+  }
+}

--- a/DietApp/View/SettingsPage/Cell/DeleteData/DataDeletionExecutionView/Cell/DeleteAllDataTableViewCell.swift
+++ b/DietApp/View/SettingsPage/Cell/DeleteData/DataDeletionExecutionView/Cell/DeleteAllDataTableViewCell.swift
@@ -7,6 +7,10 @@
 
 import UIKit
 
+protocol DeleteAllDataTableViewCellDelegate {
+  func deleteButtonAction()
+}
+
 class DeleteAllDataTableViewCell: UITableViewCell {
 
   @IBOutlet weak var shadowLayerview: UIView!
@@ -22,6 +26,8 @@ class DeleteAllDataTableViewCell: UITableViewCell {
       deleteButton.setImage(image, for: .normal)
     }
   }
+  
+  var delegate: DeleteAllDataTableViewCellDelegate?
     
   
   override func awakeFromNib() {
@@ -35,5 +41,8 @@ class DeleteAllDataTableViewCell: UITableViewCell {
 
         // Configure the view for the selected state
     }
-    
+  @IBAction func deleteButtonAction(_ sender: UIButton) {
+    delegate?.deleteButtonAction()
+  }
+  
 }

--- a/DietApp/View/SettingsPage/Cell/DeleteData/DataDeletionExecutionView/Cell/DeleteAllDataTableViewCell.xib
+++ b/DietApp/View/SettingsPage/Cell/DeleteData/DataDeletionExecutionView/Cell/DeleteAllDataTableViewCell.xib
@@ -33,6 +33,9 @@
                                 </constraints>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="plain" image="trash.fill" catalog="system"/>
+                                <connections>
+                                    <action selector="deleteButtonAction:" destination="KGk-i7-Jjw" eventType="touchUpInside" id="coj-Ts-dv7"/>
+                                </connections>
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="全てのデータを削除" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="leY-Aw-bID">
                                 <rect key="frame" x="12" y="12.666666666666668" width="143.66666666666666" height="23.000000000000004"/>

--- a/DietAppTests/ModelTests/DataDeleteManagerTest.swift
+++ b/DietAppTests/ModelTests/DataDeleteManagerTest.swift
@@ -1,0 +1,96 @@
+//
+//  DataDeleteManagerTest.swift
+//  DietAppTests
+//
+//  Created by 川島真之 on 2024/12/15.
+//
+
+import XCTest
+import RealmSwift
+@testable import DietApp
+
+class TestRealmObject: Object {
+    @Persisted var id = UUID().uuidString
+}
+
+final class DataDeleteManagerTests: XCTestCase {
+    
+    var sut: DataDeleteManager!
+    var realm: Realm!
+    var fileManager: FileManager!
+    
+    override func setUp() {
+        super.setUp()
+        sut = DataDeleteManager.shared
+        realm = try! Realm()
+        fileManager = FileManager.default
+        
+        // テスト用のRealmオブジェクトとファイルを作成
+        setupTestData()
+    }
+    
+    override func tearDown() {
+        sut = nil
+        realm = nil
+        fileManager = nil
+        super.tearDown()
+    }
+    
+    private func setupTestData() {
+        // テスト用のRealmオブジェクトを作成
+        try! realm.write {
+            let testObject = TestRealmObject()
+            realm.add(testObject)
+        }
+        
+        // テスト用のファイルを作成
+        if let documentPath = fileManager.urls(for: .documentDirectory, in: .userDomainMask).first {
+            let testFilePath = documentPath.appendingPathComponent("testFile.txt")
+            try? "Test Data".write(to: testFilePath, atomically: true, encoding: .utf8)
+        }
+    }
+  //成功の場合のテスト
+    func testDeleteAllData_Success() {
+      
+        let result = sut.deleteAllData()
+
+        XCTAssertTrue(result)
+        
+       //念の為Realmとドキュメントディレクトリの中身が空になっているか確認
+        XCTAssertEqual(realm.objects(TestRealmObject.self).count, 0)
+        
+        // ドキュメントディレクトリ内にファイルが存在しないことを確認
+        if let documentPath = fileManager.urls(for: .documentDirectory, in: .userDomainMask).first {
+            let contents = try? fileManager.contentsOfDirectory(at: documentPath, includingPropertiesForKeys: nil, options: [])
+            XCTAssertTrue(contents?.isEmpty ?? false)
+        }
+    }
+    //ドキュメントディレクトリがすでにからの場合のテスト
+    func testDeleteAllData_EmptyDirectorySuccess() {
+        // Given
+        // ドキュメントディレクトリを事前にクリア
+        if let documentPath = fileManager.urls(for: .documentDirectory, in: .userDomainMask).first {
+            let contents = try? fileManager.contentsOfDirectory(at: documentPath, includingPropertiesForKeys: nil, options: [])
+            try? contents?.forEach { url in
+                try fileManager.removeItem(at: url)
+            }
+        }
+        
+        // When
+        let result = sut.deleteAllData()
+        
+        // Then
+        XCTAssertTrue(result)
+    }
+  //RealmObjectが存在しない場合のテスト
+  func testDeleteAllData_EmptyRealmObjectSuccess() {
+    //全てのRealmObjectを事前に削除
+    try! realm.write {
+      realm.deleteAll()
+    }
+    
+    let result = sut.deleteAllData()
+    XCTAssertTrue(result)
+  }
+}
+


### PR DESCRIPTION
## issue
close #148 

## やったこと

- 全データ削除のボタンを押した時の最終確認のアラートの実装
- データ削除に成功した場合のアラートの実装
- データ削除のモデルの作成とテスト

## やっていないこと

- データ削除モデルの実装

- データ削除に失敗した場合のアラートの実装

## その他
